### PR TITLE
Add power rankings, league leaders and player stat endpoints

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -16,6 +16,13 @@ env_variables:
   BQ_DATASET: mlb_historical_data
   USE_DEFAULT_GCP_CREDENTIALS: true
   CURRENT_SEASON: 2026
+  # Football and rankings datasets. The code defaults to these same values, but naming
+  # them here keeps production config readable instead of implicit.
+  NFL_DATASET: nfl_season
+  NFL_HIST_DATASET: nfl_historical
+  CFB_DATASET: cfb_season
+  CFB_HIST_DATASET: cfb_historical
+  MLB_RANKINGS_DATASET: mlb_2026_season
   MIN_SEASON: 2015
   MAX_SEASON: 2026
   # Injected at deploy time from the NEWS_API_KEY env var / GitHub secret.

--- a/src/app.ts
+++ b/src/app.ts
@@ -13,6 +13,7 @@ import predictionsRoutes from './routes/predictions.routes';
 import scoutingReportsRoutes from './routes/scouting-reports.routes';
 import nflRoutes from './routes/nfl.routes';
 import footballRoutes from './routes/football.routes';
+import rankingsRoutes from './routes/rankings.routes';
 import { validateGCPConfig } from './config/gcp.config';
 import { schedulerService } from './services/scheduler.service';
 
@@ -67,6 +68,7 @@ app.use('/api/lineup', lineupRoutes); // Lineup scheduling and pre-game task man
 app.use('/api/predictions', predictionsRoutes); // Game predictions and matchup signals
 app.use('/api/scouting-reports', scoutingReportsRoutes); // Pre-computed daily scouting reports
 app.use('/api/football', footballRoutes); // NFL + CFB predictions, accuracy, searchable stats
+app.use('/api/rankings', rankingsRoutes); // Bradley-Terry power rankings, all sports
 app.use('/api/nfl', nflRoutes); // legacy alias for /api/football/nfl
 app.use('/api', legacyRoutes); // Legacy endpoints for backward compatibility
 

--- a/src/config/football.config.ts
+++ b/src/config/football.config.ts
@@ -16,10 +16,22 @@ export interface FootballSportConfig {
   gamesTable: string;
   /** Per-team, per-week advanced stats. NFL has EPA; CFB has none from the free feed. */
   statsTable: string | null;
+  /** Per-team SEASON totals, including opponent splits (college only). */
+  teamSeasonTable: string | null;
+  /** Full per-player season table. NFL only — see playerNote for why. */
+  playerTable: string | null;
+  /** League leaders, long-form: one row per (category, rank). */
+  leadersTable: string | null;
+  /** Shown in place of a player search the sport cannot support. */
+  playerNote?: string;
+  sortableSeasonFields?: string[];
   /** CFB splits FBS/FCS via a division column; NFL has no such split. */
   hasDivisions: boolean;
   sortableStatFields: string[];
-  /** Bradley-Terry power rankings. CFB only so far. */
+  /**
+   * Bradley-Terry power rankings. Every sport now has a board; rankings themselves are
+   * served by rankings.controller, so this only records that the sport has one.
+   */
   rankingsTable: string | null;
 }
 
@@ -41,7 +53,10 @@ export const FOOTBALL_SPORTS: Record<string, FootballSportConfig> = {
     statsTable: 'team_week_epa',
     hasDivisions: false,
     sortableStatFields: NFL_STAT_FIELDS,
-    rankingsTable: null,
+    teamSeasonTable: null,
+    playerTable: 'player_season_stats',
+    leadersTable: 'stat_leaders',
+    rankingsTable: 'power_rankings',
   },
   cfb: {
     key: 'cfb',
@@ -53,6 +68,18 @@ export const FOOTBALL_SPORTS: Record<string, FootballSportConfig> = {
     statsTable: null,
     hasDivisions: true,
     sortableStatFields: [],
+    teamSeasonTable: 'team_season_stats',
+    playerTable: null,
+    leadersTable: 'stat_leaders',
+    // No public ESPN endpoint returns a full college per-player season table: the
+    // sortable athlete endpoint returns "-" for the very stat it sorts on, and passing
+    // an explicit category 400s. Leaders are what the feed can actually support.
+    playerNote: 'College player stats are limited to league leaders — the public feed '
+      + 'does not publish a full per-player season table.',
+    sortableSeasonFields: [
+      'totalPointsPerGame', 'totalYards', 'passingYards', 'rushingYards',
+      'yardsPerGame', 'completionPct', 'opp_totalPointsPerGame', 'opp_totalYards',
+    ],
     rankingsTable: 'power_rankings',
   },
 };

--- a/src/config/rankings.config.ts
+++ b/src/config/rankings.config.ts
@@ -1,0 +1,59 @@
+/**
+ * Power-rankings registry.
+ *
+ * Ratings are produced by one sport-neutral Bradley-Terry fit (rankings/build.py in the
+ * ML repo) and land in a `power_rankings` table per sport, all with the same schema. So
+ * unlike predictions — where football and baseball have genuinely different columns —
+ * one controller can serve every sport, and this table is the only thing that differs.
+ */
+
+export interface RankingSportConfig {
+  key: string;
+  label: string;
+  datasetEnv: string;
+  defaultDataset: string;
+  table: string;
+  /** Boards are split per division (college); others rank one pool. */
+  divisions: string[];
+  /** Rendered as the method note so each sport can be honest about its own limits. */
+  note?: string;
+}
+
+export const RANKING_SPORTS: Record<string, RankingSportConfig> = {
+  nfl: {
+    key: 'nfl',
+    label: 'NFL',
+    datasetEnv: 'NFL_DATASET',
+    defaultDataset: 'nfl_season',
+    table: 'power_rankings',
+    divisions: [],
+  },
+  cfb: {
+    key: 'cfb',
+    label: 'College Football',
+    datasetEnv: 'CFB_DATASET',
+    defaultDataset: 'cfb_season',
+    table: 'power_rankings',
+    divisions: ['fbs', 'fcs'],
+    note: 'FBS and FCS are fitted together so the two ladders stay comparable; '
+      + 'ranks are numbered within a board and overall_rank spans both.',
+  },
+  mlb: {
+    key: 'mlb',
+    label: 'MLB',
+    datasetEnv: 'MLB_RANKINGS_DATASET',
+    defaultDataset: 'mlb_2026_season',
+    table: 'power_rankings',
+    divisions: [],
+    // Stated because the number invites more confidence than it deserves: measured
+    // walk-forward over 2023-2025, team strength moves baseball log loss from 0.6931
+    // (a coin flip) only to 0.6808. The ordering is a fair summary of who has played
+    // best; it is not a useful game predictor, and the rank ranges show why.
+    note: 'Baseball separates far less than football — the rank range column is wide '
+      + 'because the results genuinely do not distinguish these teams.',
+  },
+};
+
+export function getRankingSport(key: string): RankingSportConfig | null {
+  return RANKING_SPORTS[key?.toLowerCase()] || null;
+}

--- a/src/controllers/football.controller.ts
+++ b/src/controllers/football.controller.ts
@@ -17,6 +17,16 @@ import { getFootballSport, FootballSportConfig } from '../config/football.config
 const PROJECT = process.env.GCP_PROJECT_ID || 'hankstank';
 const bigquery = new BigQuery({ projectId: PROJECT });
 
+// Sortable player columns, allow-listed because BigQuery cannot parameterize an
+// ORDER BY identifier and the value arrives from the query string.
+const NFL_PLAYER_SORT_FIELDS = [
+  'passing_yards', 'passing_tds', 'passing_epa', 'passing_interceptions',
+  'completions', 'attempts', 'rushing_yards', 'rushing_tds', 'carries',
+  'rushing_epa', 'receiving_yards', 'receiving_tds', 'receptions', 'targets',
+  'receiving_epa', 'def_sacks', 'def_tackles_solo', 'def_interceptions',
+  'def_pass_defended', 'games',
+];
+
 function resolveSport(req: Request, res: Response): FootballSportConfig | null {
   const key = (req.params.sport || 'nfl').toLowerCase();
   const sport = getFootballSport(key);
@@ -223,72 +233,6 @@ export async function searchTeamStats(req: Request, res: Response): Promise<void
   }
 }
 
-/**
- * GET /api/football/:sport/rankings?season=
- *
- * Bradley-Terry power ratings: one global maximum-likelihood fit over every game,
- * rather than a path-dependent Elo walk. Ships the uncertainty alongside the order —
- * bootstrap rank ranges and the probability each team beats the one below it — because
- * outside the top couple of spots the ordering is not statistically meaningful.
- */
-export async function getRankings(req: Request, res: Response): Promise<void> {
-  const sport = resolveSport(req, res);
-  if (!sport) return;
-
-  if (!sport.rankingsTable) {
-    res.json({
-      success: true,
-      data: [],
-      meta: { sport: sport.key, note: 'No power rankings for this sport yet.' },
-    });
-    return;
-  }
-
-  try {
-    const season = parseInt((req.query.season as string) || '2025', 10);
-    const limit = Math.min(parseInt((req.query.limit as string) || '25', 10), 100);
-
-    // as_of_week lets the table hold a weekly history; take the latest snapshot.
-    const sql = `
-      SELECT * FROM \`${PROJECT}.${sport.seasonDataset}.${sport.rankingsTable}\`
-      WHERE season = @season
-        AND as_of_week = (
-          SELECT MAX(as_of_week)
-          FROM \`${PROJECT}.${sport.seasonDataset}.${sport.rankingsTable}\`
-          WHERE season = @season
-        )
-      ORDER BY rank
-      LIMIT @limit
-    `;
-
-    const [rows] = await bigquery.query({ query: sql, params: { season, limit } });
-    const first: any = rows[0] || {};
-    res.json({
-      success: true,
-      data: rows,
-      meta: {
-        sport: sport.key,
-        season,
-        count: rows.length,
-        as_of_week: first.as_of_week ?? null,
-        home_field_points: first.home_field_points ?? null,
-        fbs_over_fcs_points: first.fbs_over_fcs_points ?? null,
-        prior_weight: first.prior_weight ?? null,
-        method: 'Bradley-Terry, ridge-regularized, with an explicit division baseline '
-          + 'and a decaying prior on the previous season',
-      },
-    });
-  } catch (error: any) {
-    logger.error('football rankings query failed', {
-      sport: sport.key, error: error.message,
-    });
-    res.status(500).json({
-      success: false,
-      error: { code: 'RANKINGS_ERROR', message: 'Failed to load power rankings' },
-    });
-  }
-}
-
 /** GET /api/football/:sport/stats/games — searchable game results. */
 export async function searchGames(req: Request, res: Response): Promise<void> {
   const sport = resolveSport(req, res);
@@ -339,6 +283,192 @@ export async function searchGames(req: Request, res: Response): Promise<void> {
     res.status(500).json({
       success: false,
       error: { code: 'GAMES_ERROR', message: 'Failed to search games' },
+    });
+  }
+}
+
+/**
+ * GET /api/football/:sport/stats/leaders?season=&category=&limit=
+ *
+ * Long-form: one row per (category, rank), so a client can render every category at
+ * once or filter to one without a second shape to handle.
+ */
+export async function getLeaders(req: Request, res: Response): Promise<void> {
+  const sport = resolveSport(req, res);
+  if (!sport) return;
+
+  if (!sport.leadersTable) {
+    res.json({
+      success: true,
+      data: [],
+      meta: { sport: sport.key, note: 'No league leaders for this sport yet.' },
+    });
+    return;
+  }
+
+  try {
+    const season = parseInt((req.query.season as string) || '', 10);
+    if (!Number.isFinite(season)) {
+      res.status(400).json({
+        success: false,
+        error: { code: 'BAD_SEASON', message: 'season is required' },
+      });
+      return;
+    }
+
+    const category = (req.query.category as string) || '';
+    const limit = Math.min(parseInt((req.query.limit as string) || '400', 10), 500);
+
+    const filters = ['season = @season'];
+    const params: Record<string, any> = { season, limit };
+    if (category) {
+      filters.push('category = @category');
+      params.category = category;
+    }
+
+    const table = `${PROJECT}.${sport.seasonDataset}.${sport.leadersTable}`;
+    const [rows] = await bigquery.query({
+      query: `SELECT * FROM \`${table}\`
+              WHERE ${filters.join(' AND ')}
+              ORDER BY category_label, rank
+              LIMIT @limit`,
+      params,
+    });
+
+    const categories = Array.from(
+      new Map(
+        rows.map((r: any) => [r.category, r.category_label])
+      ).entries()
+    ).map(([key, label]) => ({ key, label }));
+
+    res.json({
+      success: true,
+      data: rows,
+      meta: { sport: sport.key, season, count: rows.length, categories },
+    });
+  } catch (error: any) {
+    if (/not found|does not exist/i.test(error?.message || '')) {
+      res.json({
+        success: true,
+        data: [],
+        meta: { sport: sport.key, note: 'League leaders have not been built yet.' },
+      });
+      return;
+    }
+    logger.error('football leaders query failed', {
+      sport: sport.key, error: error.message,
+    });
+    res.status(500).json({
+      success: false,
+      error: { code: 'LEADERS_ERROR', message: 'Failed to load league leaders' },
+    });
+  }
+}
+
+/**
+ * GET /api/football/:sport/stats/players?season=&search=&position=&sort=&limit=
+ *
+ * A sport without a player table answers with its own note rather than an error — for
+ * college that is a fact about the feed, not a failure.
+ */
+export async function searchPlayers(req: Request, res: Response): Promise<void> {
+  const sport = resolveSport(req, res);
+  if (!sport) return;
+
+  if (!sport.playerTable) {
+    res.json({
+      success: true,
+      data: [],
+      meta: {
+        sport: sport.key,
+        note: sport.playerNote || 'No per-player stats for this sport yet.',
+      },
+    });
+    return;
+  }
+
+  try {
+    const season = parseInt((req.query.season as string) || '', 10);
+    if (!Number.isFinite(season)) {
+      res.status(400).json({
+        success: false,
+        error: { code: 'BAD_SEASON', message: 'season is required' },
+      });
+      return;
+    }
+
+    const search = (req.query.search as string) || '';
+    const position = (req.query.position as string) || '';
+    const team = (req.query.team as string) || '';
+    const limit = Math.min(parseInt((req.query.limit as string) || '50', 10), 200);
+    const offset = Math.max(parseInt((req.query.offset as string) || '0', 10), 0);
+
+    // Sort is interpolated, not parameterized — BigQuery cannot bind an identifier — so
+    // it is checked against an allow-list. Never pass the raw value through.
+    const requested = (req.query.sort as string) || 'passing_yards';
+    const sort = NFL_PLAYER_SORT_FIELDS.includes(requested) ? requested : 'passing_yards';
+    const dir = ((req.query.direction as string) || 'desc').toLowerCase() === 'asc'
+      ? 'ASC' : 'DESC';
+
+    const filters = ['season = @season'];
+    const params: Record<string, any> = { season, limit, offset };
+    if (search) {
+      filters.push('UPPER(player_display_name) LIKE @search');
+      params.search = `%${search.toUpperCase()}%`;
+    }
+    if (position) {
+      filters.push('UPPER(position) = @position');
+      params.position = position.toUpperCase();
+    }
+    if (team) {
+      filters.push('UPPER(recent_team) = @team');
+      params.team = team.toUpperCase();
+    }
+
+    const table = `${PROJECT}.${sport.seasonDataset}.${sport.playerTable}`;
+    const where = `WHERE ${filters.join(' AND ')}`;
+
+    const [rows] = await bigquery.query({
+      query: `SELECT * FROM \`${table}\` ${where}
+              ORDER BY ${sort} ${dir} NULLS LAST
+              LIMIT @limit OFFSET @offset`,
+      params,
+    });
+    const [[{ total }]] = await bigquery.query({
+      query: `SELECT COUNT(*) AS total FROM \`${table}\` ${where}`,
+      params,
+    }) as any;
+
+    res.json({
+      success: true,
+      data: rows,
+      meta: {
+        sport: sport.key,
+        season,
+        total,
+        count: rows.length,
+        limit,
+        offset,
+        sort,
+        direction: dir,
+        sortable_fields: NFL_PLAYER_SORT_FIELDS,
+      },
+    });
+  } catch (error: any) {
+    if (/not found|does not exist/i.test(error?.message || '')) {
+      res.json({
+        success: true,
+        data: [],
+        meta: { sport: sport.key, note: 'Player stats have not been built yet.' },
+      });
+      return;
+    }
+    logger.error('football player search failed', {
+      sport: sport.key, error: error.message,
+    });
+    res.status(500).json({
+      success: false,
+      error: { code: 'PLAYERS_ERROR', message: 'Failed to load player stats' },
     });
   }
 }

--- a/src/controllers/rankings.controller.ts
+++ b/src/controllers/rankings.controller.ts
@@ -1,0 +1,127 @@
+/**
+ * Power rankings for every sport.
+ *
+ * Served at /api/rankings/:sport, with /api/football/:sport/rankings delegating here so
+ * the football tab keeps its existing URL. The tables share a schema across sports, so
+ * the only per-sport knowledge lives in rankings.config.
+ */
+
+import { Request, Response } from 'express';
+import { BigQuery } from '@google-cloud/bigquery';
+import { logger } from '../utils/logger';
+import { getRankingSport, RankingSportConfig } from '../config/rankings.config';
+
+const PROJECT = process.env.GCP_PROJECT_ID || 'hankstank';
+const bigquery = new BigQuery({ projectId: PROJECT });
+
+const MAX_LIMIT = 400;
+
+function datasetFor(sport: RankingSportConfig): string {
+  return process.env[sport.datasetEnv] || sport.defaultDataset;
+}
+
+/**
+ * GET /api/rankings/:sport?season=&division=&limit=
+ *
+ * A missing table is reported as an empty board with a note rather than a 500: a sport
+ * whose ratings have not been built yet is an expected state, and the UI renders it as
+ * "not available" instead of an error.
+ */
+export async function getRankings(req: Request, res: Response): Promise<void> {
+  const key = (req.params.sport || '').toLowerCase();
+  const sport = getRankingSport(key);
+
+  if (!sport) {
+    res.status(404).json({
+      success: false,
+      error: { code: 'UNKNOWN_SPORT', message: `No rankings for sport: ${key}` },
+    });
+    return;
+  }
+
+  // Defaults rather than 400s on a missing season: /api/football/:sport/rankings
+  // already shipped with a default, and this handler took that path over, so
+  // rejecting the omission would break existing callers.
+  const requestedSeason = parseInt((req.query.season as string) || '', 10);
+  const season = Number.isFinite(requestedSeason)
+    ? requestedSeason
+    : parseInt(process.env.CURRENT_SEASON || '', 10) || new Date().getFullYear();
+
+  const limit = Math.min(
+    parseInt((req.query.limit as string) || '50', 10) || 50,
+    MAX_LIMIT
+  );
+  const division = ((req.query.division as string) || '').toLowerCase();
+
+  const table = `${PROJECT}.${datasetFor(sport)}.${sport.table}`;
+  const params: Record<string, any> = { season, limit };
+  const filters = ['season = @season'];
+
+  if (division && sport.divisions.includes(division)) {
+    filters.push('division = @division');
+    params.division = division;
+  }
+
+  // as_of_week lets the table keep a weekly history; take the latest snapshot only.
+  const sql = `
+    SELECT * FROM \`${table}\`
+    WHERE ${filters.join(' AND ')}
+      AND as_of_week = (
+        SELECT MAX(as_of_week) FROM \`${table}\` WHERE season = @season
+      )
+    ORDER BY rank
+    LIMIT @limit
+  `;
+
+  try {
+    const [rows] = await bigquery.query({ query: sql, params });
+    const first: any = rows[0] || {};
+
+    res.json({
+      success: true,
+      data: rows,
+      meta: {
+        sport: sport.key,
+        label: sport.label,
+        season,
+        division: params.division ?? null,
+        count: rows.length,
+        as_of_week: first.as_of_week ?? null,
+        home_field_points: first.home_field_points ?? null,
+        prior_weight: first.prior_weight ?? null,
+        record_season: first.record_season ?? null,
+        // No games played yet: the board is entirely last season's evidence, which the
+        // UI must say out loud rather than presenting it as this season's form.
+        is_preseason: first.record_season != null && first.record_season !== season,
+        divisions: sport.divisions,
+        method: 'Bradley-Terry, ridge-regularized, fitted globally over every game '
+          + 'with an explicit home-field term and a decaying prior on last season',
+        note: sport.note ?? null,
+      },
+    });
+  } catch (error: any) {
+    const missingTable = /not found|does not exist/i.test(error?.message || '');
+    if (missingTable) {
+      logger.warn('power rankings table missing', { sport: sport.key, table });
+      res.json({
+        success: true,
+        data: [],
+        meta: {
+          sport: sport.key,
+          season,
+          count: 0,
+          note: `No power rankings built for ${sport.label} yet.`,
+        },
+      });
+      return;
+    }
+
+    logger.error('power rankings query failed', {
+      sport: sport.key, error: error.message,
+    });
+    res.status(500).json({
+      success: false,
+      error: { code: 'RANKINGS_ERROR', message: 'Failed to load power rankings' },
+    });
+  }
+}

--- a/src/routes/football.routes.ts
+++ b/src/routes/football.routes.ts
@@ -11,8 +11,12 @@ import {
   getAccuracy,
   searchTeamStats,
   searchGames,
-  getRankings,
+  getLeaders,
+  searchPlayers,
 } from '../controllers/football.controller';
+// Rankings share one schema across every sport, so they share one controller; this
+// path stays only so the football tab's existing URL keeps working.
+import { getRankings } from '../controllers/rankings.controller';
 
 const router = Router({ mergeParams: true });
 
@@ -21,6 +25,8 @@ router.get('/:sport/predictions/accuracy', getAccuracy);
 router.get('/:sport/predictions', getPredictions);
 router.get('/:sport/rankings', getRankings);
 router.get('/:sport/stats/teams', searchTeamStats);
+router.get('/:sport/stats/leaders', getLeaders);
+router.get('/:sport/stats/players', searchPlayers);
 router.get('/:sport/stats/games', searchGames);
 
 export default router;

--- a/src/routes/rankings.routes.ts
+++ b/src/routes/rankings.routes.ts
@@ -1,0 +1,15 @@
+/**
+ * Sport-neutral power rankings: /api/rankings/:sport (nfl | cfb | mlb).
+ *
+ * /api/football/:sport/rankings delegates to the same handler so the football tab's
+ * existing URL keeps working.
+ */
+
+import { Router } from 'express';
+import { getRankings } from '../controllers/rankings.controller';
+
+const router = Router({ mergeParams: true });
+
+router.get('/:sport', getRankings);
+
+export default router;


### PR DESCRIPTION
## What

Serves the new Bradley-Terry power-ranking boards and football stat tables.

- `GET /api/rankings/:sport` — `nfl` | `cfb` | `mlb`, with `division` splitting the
  college board server-side.
- `GET /api/football/:sport/stats/leaders` — long-form, one row per (category, rank).
- `GET /api/football/:sport/stats/players` — searchable, sortable player table.
- NFL and CFB gain `power_rankings`; CFB gains `team_season_stats`.

## Why one rankings controller

Rankings share a single schema across every sport, unlike predictions where
football and baseball have genuinely different columns. So one controller serves
all three, and `/api/football/:sport/rankings` delegates to it rather than keeping
a near-duplicate. The only per-sport knowledge lives in `rankings.config.ts`.

## Two deliberate choices

**A missing table is not a 500.** A sport whose ratings have not been built yet is
an expected state, so it answers with an empty board and a note and the UI renders
"not available". College genuinely has no per-player season table to serve, and
says so.

**`season` stays optional on the rankings route.** The football path this handler
took over already defaulted it, so requiring it would have been a silent breaking
change for existing callers.

`ORDER BY` on the player route is allow-listed — BigQuery cannot parameterize an
identifier and the value arrives from the query string.

## Testing

- 9 suites / 71 tests pass; `tsc --noEmit` clean.
- Routing verified locally before deploy: unknown sport → 404, college player note
  → 200.
- Deployed to App Engine and every endpoint verified against production.

🤖 Generated with Claude Code at The Home Depot