### PR TITLE
Add the pick'em contest and college football stats endpoints

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -29,6 +29,11 @@ env_variables:
   # Do not commit a literal value here — this file is public.
   NEWS_API_KEY: __NEWS_API_KEY__
   NEWS_API_BASE_URL: https://newsapi.org/v2
+  # Live college scoreboard, schedule and game detail. Substituted at deploy time from
+  # Secret Manager (secret: cfbd-api-key) by scripts/render-app-yaml.sh — the same
+  # secret the ML pipeline's Cloud Function reads, so there is one copy of the key.
+  # Do not commit a literal value here — this file is public.
+  CFBD_API_KEY: __CFBD_API_KEY__
   CORS_ORIGIN: https://hankstank.com,https://www.hankstank.com,https://frontend-dot-hankstank.uc.r.appspot.com,http://localhost:3000,http://localhost:3001
   ML_FUNCTION_URL: https://mlb-2026-daily-pipeline-127033547664.us-central1.run.app
   LINEUP_TASK_QUEUE: lineup-pregame

--- a/app.yaml
+++ b/app.yaml
@@ -29,11 +29,11 @@ env_variables:
   # Do not commit a literal value here — this file is public.
   NEWS_API_KEY: __NEWS_API_KEY__
   NEWS_API_BASE_URL: https://newsapi.org/v2
-  # Live college scoreboard, schedule and game detail. Substituted at deploy time from
-  # Secret Manager (secret: cfbd-api-key) by scripts/render-app-yaml.sh — the same
-  # secret the ML pipeline's Cloud Function reads, so there is one copy of the key.
-  # Do not commit a literal value here — this file is public.
-  CFBD_API_KEY: __CFBD_API_KEY__
+  # The CollegeFootballData key is NOT here on purpose. The backend reads it from
+  # Secret Manager at runtime as the service account App Engine already runs as
+  # (hankstank@appspot), so no deploy needs the value and this public file never sees
+  # it. Set CFBD_API_KEY in the environment to override, which is what local dev does.
+  CFBD_SECRET_NAME: cfbd-api-key
   CORS_ORIGIN: https://hankstank.com,https://www.hankstank.com,https://frontend-dot-hankstank.uc.r.appspot.com,http://localhost:3000,http://localhost:3001
   ML_FUNCTION_URL: https://mlb-2026-daily-pipeline-127033547664.us-central1.run.app
   LINEUP_TASK_QUEUE: lineup-pregame

--- a/app.yaml
+++ b/app.yaml
@@ -34,6 +34,12 @@ env_variables:
   # (hankstank@appspot), so no deploy needs the value and this public file never sees
   # it. Set CFBD_API_KEY in the environment to override, which is what local dev does.
   CFBD_SECRET_NAME: cfbd-api-key
+  PICKEM_DATASET: pickem
+  # Web OAuth client ID for Google sign-in. Public by design — it identifies the app,
+  # not the user, and the browser needs it to render the sign-in button. It is also the
+  # audience the server verifies ID tokens against, so the two cannot drift apart.
+  # Created once in the Cloud console under APIs & Services > Credentials.
+  GOOGLE_CLIENT_ID: ""
   CORS_ORIGIN: https://hankstank.com,https://www.hankstank.com,https://frontend-dot-hankstank.uc.r.appspot.com,http://localhost:3000,http://localhost:3001
   ML_FUNCTION_URL: https://mlb-2026-daily-pipeline-127033547664.us-central1.run.app
   LINEUP_TASK_QUEUE: lineup-pregame

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@google-cloud/bigquery": "^7.9.4",
+        "@google-cloud/secret-manager": "^7.0.0",
         "@google-cloud/storage": "^7.17.0",
         "@google-cloud/tasks": "^6.2.1",
         "@types/node-cron": "^3.0.11",
@@ -28,6 +29,9 @@
         "jest": "^29.7.0",
         "ts-jest": "^29.1.2",
         "typescript": "^5.9.2"
+      },
+      "engines": {
+        "node": ">=22 <23"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -678,6 +682,188 @@
         "node": ">=14"
       }
     },
+    "node_modules/@google-cloud/secret-manager": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/secret-manager/-/secret-manager-7.0.0.tgz",
+      "integrity": "sha512-rviFJl79r/fxeXwDFCIziNGu2ZnQ7zOJJpoOl3AXys21Br8C/x5+18Y7gtOkrwGVrPDvqeDPjtB8yEHiaiS7SA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-gax": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@google-cloud/secret-manager/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@google-cloud/secret-manager/node_modules/gaxios": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
+      "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/secret-manager/node_modules/gcp-metadata": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-9.0.3.tgz",
+      "integrity": "sha512-2YYnIlHaKBGT2IPg3G2M57hia9Galz15zsEOvw9T3oRf0lSn6KN6VcHQLqby7x8ksYKnjXvp3rp2KJyLCN6zfQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.1.3",
+        "google-logging-utils": "^2.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@google-cloud/secret-manager/node_modules/google-auth-library": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-11.0.2.tgz",
+      "integrity": "sha512-vzpgPutxrghPsnjrjpzLX2bdv8IOL719Rh0oEjGnQu8YCIbnbMuTTQ5zU9LcKvLdOPgCxBwppbvnhgW90Qna5Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "^9.0.0",
+        "google-logging-utils": "^2.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@google-cloud/secret-manager/node_modules/google-gax": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-6.1.0.tgz",
+      "integrity": "sha512-PN84pgPw6USmNfy8hlMkifsII+VzCTddRODjPqGZ0JKQuB3WYMEMMepTypmE7ymMXFYiOe3Oi0dHskQ4jkOZfg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.12.6",
+        "@grpc/proto-loader": "^0.8.0",
+        "@opentelemetry/api": "^1.9.0",
+        "duplexify": "^4.1.3",
+        "google-auth-library": "^11.0.0",
+        "google-logging-utils": "^2.0.0",
+        "node-fetch": "^3.3.2",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "^4.0.0",
+        "protobufjs": "^7.5.4",
+        "retry-request": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@google-cloud/secret-manager/node_modules/google-logging-utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-2.0.1.tgz",
+      "integrity": "sha512-HMhaQghlOTvbcb3c4T5jmmOMtG3JUF1iOQMezaJXL86CDS+Tm2vHd0IeLFRAx3+ewd+bo9E1HFHoy17X5aJa9A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@google-cloud/secret-manager/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@google-cloud/secret-manager/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@google-cloud/secret-manager/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@google-cloud/secret-manager/node_modules/proto3-json-serializer": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-4.0.2.tgz",
+      "integrity": "sha512-VUQlb/J2WjOG8BKhdLwJUz+MKxSMtBGYh+TaNmRtiYVhlIzXjzeAGIx7gtc3lXlA2iURzfF2+cXaQvC2ofwzpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "protobufjs": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@google-cloud/secret-manager/node_modules/retry-request": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-9.0.1.tgz",
+      "integrity": "sha512-4kGHEBl0ME6gR+8QB1sPMyg58jUxLUcCZNeqLDrfqzk0eWQN8XJFmeu7fmZCjlZCRW0S2u64Ik1HkO/0sWgCYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "teeny-request": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@google-cloud/secret-manager/node_modules/teeny-request": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-11.0.1.tgz",
+      "integrity": "sha512-bNr5j2YjSdajgCVsp+8JVjRf1uHIbpNISLeKp/7V1NnVMX3Gh6H/kECNGlm2Q3I68ACODQ0iv6aZ3Rvm8WgLGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "stream-events": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "node_modules/@google-cloud/storage": {
       "version": "7.17.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.17.0.tgz",
@@ -1241,6 +1427,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -6889,6 +7084,132 @@
       "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-4.0.0.tgz",
       "integrity": "sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g=="
     },
+    "@google-cloud/secret-manager": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/secret-manager/-/secret-manager-7.0.0.tgz",
+      "integrity": "sha512-rviFJl79r/fxeXwDFCIziNGu2ZnQ7zOJJpoOl3AXys21Br8C/x5+18Y7gtOkrwGVrPDvqeDPjtB8yEHiaiS7SA==",
+      "requires": {
+        "google-gax": "^6.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+          "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "gaxios": {
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
+          "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
+          "requires": {
+            "extend": "^3.0.2",
+            "https-proxy-agent": "^7.0.1",
+            "node-fetch": "^3.3.2"
+          }
+        },
+        "gcp-metadata": {
+          "version": "9.0.3",
+          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-9.0.3.tgz",
+          "integrity": "sha512-2YYnIlHaKBGT2IPg3G2M57hia9Galz15zsEOvw9T3oRf0lSn6KN6VcHQLqby7x8ksYKnjXvp3rp2KJyLCN6zfQ==",
+          "requires": {
+            "gaxios": "^7.1.3",
+            "google-logging-utils": "^2.0.0",
+            "json-bigint": "^1.0.0"
+          }
+        },
+        "google-auth-library": {
+          "version": "11.0.2",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-11.0.2.tgz",
+          "integrity": "sha512-vzpgPutxrghPsnjrjpzLX2bdv8IOL719Rh0oEjGnQu8YCIbnbMuTTQ5zU9LcKvLdOPgCxBwppbvnhgW90Qna5Q==",
+          "requires": {
+            "base64-js": "^1.3.0",
+            "ecdsa-sig-formatter": "^1.0.11",
+            "gaxios": "^7.1.4",
+            "gcp-metadata": "^9.0.0",
+            "google-logging-utils": "^2.0.0",
+            "jws": "^4.0.0"
+          }
+        },
+        "google-gax": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-6.1.0.tgz",
+          "integrity": "sha512-PN84pgPw6USmNfy8hlMkifsII+VzCTddRODjPqGZ0JKQuB3WYMEMMepTypmE7ymMXFYiOe3Oi0dHskQ4jkOZfg==",
+          "requires": {
+            "@grpc/grpc-js": "^1.12.6",
+            "@grpc/proto-loader": "^0.8.0",
+            "@opentelemetry/api": "^1.9.0",
+            "duplexify": "^4.1.3",
+            "google-auth-library": "^11.0.0",
+            "google-logging-utils": "^2.0.0",
+            "node-fetch": "^3.3.2",
+            "object-hash": "^3.0.0",
+            "proto3-json-serializer": "^4.0.0",
+            "protobufjs": "^7.5.4",
+            "retry-request": "^9.0.0"
+          }
+        },
+        "google-logging-utils": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-2.0.1.tgz",
+          "integrity": "sha512-HMhaQghlOTvbcb3c4T5jmmOMtG3JUF1iOQMezaJXL86CDS+Tm2vHd0IeLFRAx3+ewd+bo9E1HFHoy17X5aJa9A=="
+        },
+        "http-proxy-agent": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+          "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+          "requires": {
+            "agent-base": "^7.1.0",
+            "debug": "^4.3.4"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        },
+        "node-fetch": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+          "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+          "requires": {
+            "data-uri-to-buffer": "^4.0.0",
+            "fetch-blob": "^3.1.4",
+            "formdata-polyfill": "^4.0.10"
+          }
+        },
+        "proto3-json-serializer": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-4.0.2.tgz",
+          "integrity": "sha512-VUQlb/J2WjOG8BKhdLwJUz+MKxSMtBGYh+TaNmRtiYVhlIzXjzeAGIx7gtc3lXlA2iURzfF2+cXaQvC2ofwzpg==",
+          "requires": {
+            "protobufjs": "^7.5.4"
+          }
+        },
+        "retry-request": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-9.0.1.tgz",
+          "integrity": "sha512-4kGHEBl0ME6gR+8QB1sPMyg58jUxLUcCZNeqLDrfqzk0eWQN8XJFmeu7fmZCjlZCRW0S2u64Ik1HkO/0sWgCYQ==",
+          "requires": {
+            "extend": "^3.0.2",
+            "teeny-request": "^11.0.0"
+          }
+        },
+        "teeny-request": {
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-11.0.1.tgz",
+          "integrity": "sha512-bNr5j2YjSdajgCVsp+8JVjRf1uHIbpNISLeKp/7V1NnVMX3Gh6H/kECNGlm2Q3I68ACODQ0iv6aZ3Rvm8WgLGA==",
+          "requires": {
+            "http-proxy-agent": "^7.0.0",
+            "https-proxy-agent": "^7.0.1",
+            "node-fetch": "^3.3.2",
+            "stream-events": "^1.0.5"
+          }
+        }
+      }
+    },
     "@google-cloud/storage": {
       "version": "7.17.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.17.0.tgz",
@@ -7294,6 +7615,11 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
       "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="
+    },
+    "@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="
     },
     "@pkgjs/parseargs": {
       "version": "0.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.6.1",
         "express": "^4.19.1",
+        "google-auth-library": "^11.0.2",
         "node-cron": "^4.2.1",
         "winston": "^3.17.0"
       },
@@ -642,6 +643,46 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@google-cloud/common/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@google-cloud/paginator": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.2.tgz",
@@ -711,51 +752,6 @@
         }
       }
     },
-    "node_modules/@google-cloud/secret-manager/node_modules/gaxios": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
-      "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^7.0.1",
-        "node-fetch": "^3.3.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@google-cloud/secret-manager/node_modules/gcp-metadata": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-9.0.3.tgz",
-      "integrity": "sha512-2YYnIlHaKBGT2IPg3G2M57hia9Galz15zsEOvw9T3oRf0lSn6KN6VcHQLqby7x8ksYKnjXvp3rp2KJyLCN6zfQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "gaxios": "^7.1.3",
-        "google-logging-utils": "^2.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@google-cloud/secret-manager/node_modules/google-auth-library": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-11.0.2.tgz",
-      "integrity": "sha512-vzpgPutxrghPsnjrjpzLX2bdv8IOL719Rh0oEjGnQu8YCIbnbMuTTQ5zU9LcKvLdOPgCxBwppbvnhgW90Qna5Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^7.1.4",
-        "gcp-metadata": "^9.0.0",
-        "google-logging-utils": "^2.0.0",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
     "node_modules/@google-cloud/secret-manager/node_modules/google-gax": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-6.1.0.tgz",
@@ -774,15 +770,6 @@
         "protobufjs": "^7.5.4",
         "retry-request": "^9.0.0"
       },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@google-cloud/secret-manager/node_modules/google-logging-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-2.0.1.tgz",
-      "integrity": "sha512-HMhaQghlOTvbcb3c4T5jmmOMtG3JUF1iOQMezaJXL86CDS+Tm2vHd0IeLFRAx3+ewd+bo9E1HFHoy17X5aJa9A==",
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=22"
       }
@@ -886,6 +873,46 @@
         "teeny-request": "^9.0.0",
         "uuid": "^8.0.0"
       },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
       }
@@ -3277,17 +3304,49 @@
       }
     },
     "node_modules/gcp-metadata": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
-      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-9.0.3.tgz",
+      "integrity": "sha512-2YYnIlHaKBGT2IPg3G2M57hia9Galz15zsEOvw9T3oRf0lSn6KN6VcHQLqby7x8ksYKnjXvp3rp2KJyLCN6zfQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "gaxios": "^6.1.1",
-        "google-logging-utils": "^0.0.2",
+        "gaxios": "^7.1.3",
+        "google-logging-utils": "^2.0.0",
         "json-bigint": "^1.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=22"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/gaxios": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
+      "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/gensync": {
@@ -3392,20 +3451,52 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "9.15.1",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
-      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-11.0.2.tgz",
+      "integrity": "sha512-vzpgPutxrghPsnjrjpzLX2bdv8IOL719Rh0oEjGnQu8YCIbnbMuTTQ5zU9LcKvLdOPgCxBwppbvnhgW90Qna5Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^6.1.1",
-        "gcp-metadata": "^6.1.0",
-        "gtoken": "^7.0.0",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "^9.0.0",
+        "google-logging-utils": "^2.0.0",
         "jws": "^4.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=22"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/gaxios": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
+      "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/google-gax": {
@@ -3594,12 +3685,12 @@
       }
     },
     "node_modules/google-logging-utils": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
-      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-2.0.1.tgz",
+      "integrity": "sha512-HMhaQghlOTvbcb3c4T5jmmOMtG3JUF1iOQMezaJXL86CDS+Tm2vHd0IeLFRAx3+ewd+bo9E1HFHoy17X5aJa9A==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=14"
+        "node": ">=22"
       }
     },
     "node_modules/gopd": {
@@ -7058,6 +7149,36 @@
         "html-entities": "^2.5.2",
         "retry-request": "^7.0.0",
         "teeny-request": "^9.0.0"
+      },
+      "dependencies": {
+        "gcp-metadata": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+          "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+          "requires": {
+            "gaxios": "^6.1.1",
+            "google-logging-utils": "^0.0.2",
+            "json-bigint": "^1.0.0"
+          }
+        },
+        "google-auth-library": {
+          "version": "9.15.1",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+          "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+          "requires": {
+            "base64-js": "^1.3.0",
+            "ecdsa-sig-formatter": "^1.0.11",
+            "gaxios": "^6.1.1",
+            "gcp-metadata": "^6.1.0",
+            "gtoken": "^7.0.0",
+            "jws": "^4.0.0"
+          }
+        },
+        "google-logging-utils": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+          "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ=="
+        }
       }
     },
     "@google-cloud/paginator": {
@@ -7100,39 +7221,6 @@
             "ms": "^2.1.3"
           }
         },
-        "gaxios": {
-          "version": "7.3.1",
-          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
-          "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
-          "requires": {
-            "extend": "^3.0.2",
-            "https-proxy-agent": "^7.0.1",
-            "node-fetch": "^3.3.2"
-          }
-        },
-        "gcp-metadata": {
-          "version": "9.0.3",
-          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-9.0.3.tgz",
-          "integrity": "sha512-2YYnIlHaKBGT2IPg3G2M57hia9Galz15zsEOvw9T3oRf0lSn6KN6VcHQLqby7x8ksYKnjXvp3rp2KJyLCN6zfQ==",
-          "requires": {
-            "gaxios": "^7.1.3",
-            "google-logging-utils": "^2.0.0",
-            "json-bigint": "^1.0.0"
-          }
-        },
-        "google-auth-library": {
-          "version": "11.0.2",
-          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-11.0.2.tgz",
-          "integrity": "sha512-vzpgPutxrghPsnjrjpzLX2bdv8IOL719Rh0oEjGnQu8YCIbnbMuTTQ5zU9LcKvLdOPgCxBwppbvnhgW90Qna5Q==",
-          "requires": {
-            "base64-js": "^1.3.0",
-            "ecdsa-sig-formatter": "^1.0.11",
-            "gaxios": "^7.1.4",
-            "gcp-metadata": "^9.0.0",
-            "google-logging-utils": "^2.0.0",
-            "jws": "^4.0.0"
-          }
-        },
         "google-gax": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-6.1.0.tgz",
@@ -7150,11 +7238,6 @@
             "protobufjs": "^7.5.4",
             "retry-request": "^9.0.0"
           }
-        },
-        "google-logging-utils": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-2.0.1.tgz",
-          "integrity": "sha512-HMhaQghlOTvbcb3c4T5jmmOMtG3JUF1iOQMezaJXL86CDS+Tm2vHd0IeLFRAx3+ewd+bo9E1HFHoy17X5aJa9A=="
         },
         "http-proxy-agent": {
           "version": "7.0.2",
@@ -7232,6 +7315,34 @@
         "uuid": "^8.0.0"
       },
       "dependencies": {
+        "gcp-metadata": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+          "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+          "requires": {
+            "gaxios": "^6.1.1",
+            "google-logging-utils": "^0.0.2",
+            "json-bigint": "^1.0.0"
+          }
+        },
+        "google-auth-library": {
+          "version": "9.15.1",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+          "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+          "requires": {
+            "base64-js": "^1.3.0",
+            "ecdsa-sig-formatter": "^1.0.11",
+            "gaxios": "^6.1.1",
+            "gcp-metadata": "^6.1.0",
+            "gtoken": "^7.0.0",
+            "jws": "^4.0.0"
+          }
+        },
+        "google-logging-utils": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+          "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ=="
+        },
         "mime": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
@@ -8942,13 +9053,35 @@
       }
     },
     "gcp-metadata": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
-      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-9.0.3.tgz",
+      "integrity": "sha512-2YYnIlHaKBGT2IPg3G2M57hia9Galz15zsEOvw9T3oRf0lSn6KN6VcHQLqby7x8ksYKnjXvp3rp2KJyLCN6zfQ==",
       "requires": {
-        "gaxios": "^6.1.1",
-        "google-logging-utils": "^0.0.2",
+        "gaxios": "^7.1.3",
+        "google-logging-utils": "^2.0.0",
         "json-bigint": "^1.0.0"
+      },
+      "dependencies": {
+        "gaxios": {
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
+          "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
+          "requires": {
+            "extend": "^3.0.2",
+            "https-proxy-agent": "^7.0.1",
+            "node-fetch": "^3.3.2"
+          }
+        },
+        "node-fetch": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+          "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+          "requires": {
+            "data-uri-to-buffer": "^4.0.0",
+            "fetch-blob": "^3.1.4",
+            "formdata-polyfill": "^4.0.10"
+          }
+        }
       }
     },
     "gensync": {
@@ -9015,16 +9148,38 @@
       }
     },
     "google-auth-library": {
-      "version": "9.15.1",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
-      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-11.0.2.tgz",
+      "integrity": "sha512-vzpgPutxrghPsnjrjpzLX2bdv8IOL719Rh0oEjGnQu8YCIbnbMuTTQ5zU9LcKvLdOPgCxBwppbvnhgW90Qna5Q==",
       "requires": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^6.1.1",
-        "gcp-metadata": "^6.1.0",
-        "gtoken": "^7.0.0",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "^9.0.0",
+        "google-logging-utils": "^2.0.0",
         "jws": "^4.0.0"
+      },
+      "dependencies": {
+        "gaxios": {
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
+          "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
+          "requires": {
+            "extend": "^3.0.2",
+            "https-proxy-agent": "^7.0.1",
+            "node-fetch": "^3.3.2"
+          }
+        },
+        "node-fetch": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+          "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+          "requires": {
+            "data-uri-to-buffer": "^4.0.0",
+            "fetch-blob": "^3.1.4",
+            "formdata-polyfill": "^4.0.10"
+          }
+        }
       }
     },
     "google-gax": {
@@ -9159,9 +9314,9 @@
       }
     },
     "google-logging-utils": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
-      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-2.0.1.tgz",
+      "integrity": "sha512-HMhaQghlOTvbcb3c4T5jmmOMtG3JUF1iOQMezaJXL86CDS+Tm2vHd0IeLFRAx3+ewd+bo9E1HFHoy17X5aJa9A=="
     },
     "gopd": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.6.1",
     "express": "^4.19.1",
+    "google-auth-library": "^11.0.2",
     "node-cron": "^4.2.1",
     "winston": "^3.17.0"
   },

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@google-cloud/bigquery": "^7.9.4",
+    "@google-cloud/secret-manager": "^7.0.0",
     "@google-cloud/storage": "^7.17.0",
     "@google-cloud/tasks": "^6.2.1",
     "@types/node-cron": "^3.0.11",

--- a/scripts/render-app-yaml.sh
+++ b/scripts/render-app-yaml.sh
@@ -8,10 +8,9 @@
 # Retrieve NEWS_API_KEY with: gh secret list  (values are write-only; use your
 # newsapi.org account)
 #
-# CFBD_API_KEY is different: it already lives in Secret Manager, because the ML
-# pipeline's Cloud Function reads it from there. Rather than ask you to keep a second
-# copy in your shell, this pulls it from the same place. Set CFBD_API_KEY explicitly
-# to override, which is what CI does.
+# The CollegeFootballData key is deliberately NOT handled here. The backend reads it
+# from Secret Manager at runtime, using the service account App Engine already runs as,
+# so no deploy — local or CI — needs to know the value.
 
 set -euo pipefail
 
@@ -32,37 +31,11 @@ EOF
     exit 1
 fi
 
-# Fall back to Secret Manager so the key has one home rather than two.
-if [ -z "${CFBD_API_KEY:-}" ]; then
-    CFBD_API_KEY="$(gcloud secrets versions access latest \
-        --secret=cfbd-api-key --project="$PROJECT" 2>/dev/null || true)"
-fi
+sed "s|__NEWS_API_KEY__|${NEWS_API_KEY}|" app.yaml > app.generated.yaml
 
-if [ -z "${CFBD_API_KEY:-}" ]; then
-    cat >&2 <<EOF
-ERROR: CFBD_API_KEY is not set and could not be read from Secret Manager, refusing
-to render app.yaml.
-
-Deploying without it would push the literal "__CFBD_API_KEY__" and the live college
-scoreboard, schedule and game pages would report themselves unavailable.
-
-  gcloud secrets versions access latest --secret=cfbd-api-key --project=$PROJECT
-  # or, to override:
-  export CFBD_API_KEY='<key from collegefootballdata.com/key>'
-  npm run deploy
-EOF
+if grep -q '__NEWS_API_KEY__' app.generated.yaml; then
+    echo "ERROR: placeholder substitution failed" >&2
     exit 1
 fi
 
-sed -e "s|__NEWS_API_KEY__|${NEWS_API_KEY}|" \
-    -e "s|__CFBD_API_KEY__|${CFBD_API_KEY}|" \
-    app.yaml > app.generated.yaml
-
-for placeholder in __NEWS_API_KEY__ __CFBD_API_KEY__; do
-    if grep -q "$placeholder" app.generated.yaml; then
-        echo "ERROR: $placeholder substitution failed" >&2
-        exit 1
-    fi
-done
-
-echo "Rendered app.generated.yaml (NEWS_API_KEY ${#NEWS_API_KEY} chars, CFBD_API_KEY ${#CFBD_API_KEY} chars)"
+echo "Rendered app.generated.yaml (NEWS_API_KEY injected, ${#NEWS_API_KEY} chars)"

--- a/scripts/render-app-yaml.sh
+++ b/scripts/render-app-yaml.sh
@@ -1,15 +1,23 @@
 #!/bin/bash
 # Renders app.yaml -> app.generated.yaml with secrets substituted in.
 #
-# app.yaml is public and holds only a __NEWS_API_KEY__ placeholder. The real value
-# comes from the environment: a GitHub Actions secret in CI, or your shell locally.
+# app.yaml is public and holds only __PLACEHOLDER__ tokens. The real values come from
+# the environment: GitHub Actions secrets in CI, or your shell locally.
 #
 # Local deploys:  export NEWS_API_KEY=... && npm run deploy
-# Retrieve it with: gh secret list  (values are write-only; use your newsapi.org account)
+# Retrieve NEWS_API_KEY with: gh secret list  (values are write-only; use your
+# newsapi.org account)
+#
+# CFBD_API_KEY is different: it already lives in Secret Manager, because the ML
+# pipeline's Cloud Function reads it from there. Rather than ask you to keep a second
+# copy in your shell, this pulls it from the same place. Set CFBD_API_KEY explicitly
+# to override, which is what CI does.
 
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
+
+PROJECT="${GCP_PROJECT_ID:-hankstank}"
 
 if [ -z "${NEWS_API_KEY:-}" ]; then
     cat >&2 <<'EOF'
@@ -24,11 +32,37 @@ EOF
     exit 1
 fi
 
-sed "s|__NEWS_API_KEY__|${NEWS_API_KEY}|" app.yaml > app.generated.yaml
+# Fall back to Secret Manager so the key has one home rather than two.
+if [ -z "${CFBD_API_KEY:-}" ]; then
+    CFBD_API_KEY="$(gcloud secrets versions access latest \
+        --secret=cfbd-api-key --project="$PROJECT" 2>/dev/null || true)"
+fi
 
-if grep -q '__NEWS_API_KEY__' app.generated.yaml; then
-    echo "ERROR: placeholder substitution failed" >&2
+if [ -z "${CFBD_API_KEY:-}" ]; then
+    cat >&2 <<EOF
+ERROR: CFBD_API_KEY is not set and could not be read from Secret Manager, refusing
+to render app.yaml.
+
+Deploying without it would push the literal "__CFBD_API_KEY__" and the live college
+scoreboard, schedule and game pages would report themselves unavailable.
+
+  gcloud secrets versions access latest --secret=cfbd-api-key --project=$PROJECT
+  # or, to override:
+  export CFBD_API_KEY='<key from collegefootballdata.com/key>'
+  npm run deploy
+EOF
     exit 1
 fi
 
-echo "Rendered app.generated.yaml (NEWS_API_KEY injected, ${#NEWS_API_KEY} chars)"
+sed -e "s|__NEWS_API_KEY__|${NEWS_API_KEY}|" \
+    -e "s|__CFBD_API_KEY__|${CFBD_API_KEY}|" \
+    app.yaml > app.generated.yaml
+
+for placeholder in __NEWS_API_KEY__ __CFBD_API_KEY__; do
+    if grep -q "$placeholder" app.generated.yaml; then
+        echo "ERROR: $placeholder substitution failed" >&2
+        exit 1
+    fi
+done
+
+echo "Rendered app.generated.yaml (NEWS_API_KEY ${#NEWS_API_KEY} chars, CFBD_API_KEY ${#CFBD_API_KEY} chars)"

--- a/src/__tests__/auth.middleware.test.ts
+++ b/src/__tests__/auth.middleware.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for Google client-id resolution.
+ *
+ * The retry behaviour is the point. A found id never changes and is cached for the life
+ * of the instance; a missing one must not be, because caching absence forever means
+ * storing the id later has no effect until instances are replaced — which is exactly
+ * what happened the first time sign-in was switched on.
+ */
+
+const accessSecretVersion = jest.fn();
+
+jest.mock('@google-cloud/secret-manager', () => ({
+  SecretManagerServiceClient: jest.fn().mockImplementation(() => ({
+    accessSecretVersion,
+  })),
+}));
+jest.mock('../utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+import { googleClientId, isAuthConfigured, __resetClientId } from '../middleware/auth.middleware';
+
+const ID = '127033547664-abc.apps.googleusercontent.com';
+const secret = (value: string) => [{ payload: { data: Buffer.from(value) } }];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useRealTimers();
+  __resetClientId();
+  delete process.env.GOOGLE_CLIENT_ID;
+});
+
+describe('googleClientId', () => {
+  it('reads the id from Secret Manager', async () => {
+    accessSecretVersion.mockResolvedValue(secret(ID));
+    await expect(googleClientId()).resolves.toBe(ID);
+    await expect(isAuthConfigured()).resolves.toBe(true);
+  });
+
+  it('prefers an explicit env var, so local dev needs no secret access', async () => {
+    process.env.GOOGLE_CLIENT_ID = 'from-env';
+    await expect(googleClientId()).resolves.toBe('from-env');
+    expect(accessSecretVersion).not.toHaveBeenCalled();
+  });
+
+  it('caches a found id for the life of the instance', async () => {
+    accessSecretVersion.mockResolvedValue(secret(ID));
+    await googleClientId();
+    await googleClientId();
+    await googleClientId();
+    expect(accessSecretVersion).toHaveBeenCalledTimes(1);
+  });
+
+  it('makes one upstream call for a burst of concurrent first requests', async () => {
+    accessSecretVersion.mockResolvedValue(secret(ID));
+    const all = await Promise.all([
+      googleClientId(), googleClientId(), googleClientId(),
+    ]);
+    expect(all).toEqual([ID, ID, ID]);
+    expect(accessSecretVersion).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not treat a missing id as permanent', async () => {
+    // The regression: caching absence forever meant storing the id later had no
+    // effect until the instance was replaced.
+    accessSecretVersion.mockRejectedValueOnce(new Error('NOT_FOUND'));
+    await expect(googleClientId()).resolves.toBeNull();
+
+    jest.useFakeTimers();
+    jest.setSystemTime(Date.now() + 61_000);
+    accessSecretVersion.mockResolvedValue(secret(ID));
+    await expect(googleClientId()).resolves.toBe(ID);
+  });
+
+  it('does not hammer Secret Manager while the id is still missing', async () => {
+    accessSecretVersion.mockRejectedValue(new Error('NOT_FOUND'));
+    await googleClientId();
+    await googleClientId();
+    await googleClientId();
+    // One attempt, then a quiet window rather than a call per request.
+    expect(accessSecretVersion).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports not-configured rather than throwing when the secret is unreadable', async () => {
+    accessSecretVersion.mockRejectedValue(new Error('PERMISSION_DENIED'));
+    await expect(isAuthConfigured()).resolves.toBe(false);
+  });
+});

--- a/src/__tests__/football-cache.test.ts
+++ b/src/__tests__/football-cache.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for the football response cache.
+ *
+ * The behaviour worth pinning is not "it caches" but the three judgement calls around
+ * it: a completed season is frozen and gets a long TTL, an oversized body is served but
+ * not stored, and a thrown error is never cached — a missing table must stay a missing
+ * table rather than becoming a cached empty result.
+ */
+
+import express from 'express';
+import { Server } from 'http';
+import { cacheService } from '../services/cache.service';
+import {
+  serveCached,
+  seasonAwareTTL,
+  FootballCacheKeys,
+} from '../utils/football-cache';
+
+describe('seasonAwareTTL', () => {
+  it('promotes a completed season to a day', () => {
+    expect(seasonAwareTTL(3600, 2024, 2026)).toBe(86400);
+  });
+
+  it('leaves the current season on its base TTL', () => {
+    expect(seasonAwareTTL(3600, 2026, 2026)).toBe(3600);
+  });
+
+  it('leaves a future season on its base TTL', () => {
+    expect(seasonAwareTTL(3600, 2027, 2026)).toBe(3600);
+  });
+
+  it('leaves an unspecified season on its base TTL', () => {
+    expect(seasonAwareTTL(3600, undefined, 2026)).toBe(3600);
+  });
+
+  it('never shortens a TTL that is already longer', () => {
+    expect(seasonAwareTTL(172800, 2024, 2026)).toBe(172800);
+  });
+});
+
+describe('FootballCacheKeys', () => {
+  it('is order-independent, so equivalent requests share one entry', () => {
+    const a = FootballCacheKeys.teamSeason('cfb', { season: 2025, team: 'OSU' });
+    const b = FootballCacheKeys.teamSeason('cfb', { team: 'OSU', season: 2025 });
+    expect(a).toBe(b);
+  });
+
+  it('separates sports', () => {
+    expect(FootballCacheKeys.teamSeason('cfb', { season: 2025 }))
+      .not.toBe(FootballCacheKeys.teamSeason('nfl', { season: 2025 }));
+  });
+
+  it('separates resources', () => {
+    expect(FootballCacheKeys.teamSeason('cfb', {}))
+      .not.toBe(FootballCacheKeys.teamWeek('cfb', {}));
+  });
+});
+
+describe('serveCached', () => {
+  let server: Server;
+  let baseUrl: string;
+  let produce: jest.Mock;
+
+  beforeAll((done) => {
+    const app = express();
+    app.get('/probe', async (_req, res) => {
+      await serveCached(res, 'test:probe', 60, produce as any);
+    });
+    app.get('/big', async (_req, res) => {
+      // Comfortably past the 256KB store limit.
+      const body = { success: true, data: 'x'.repeat(400 * 1024) };
+      await serveCached(res, 'test:big', 60, async () => {
+        (produce as any)();
+        return body;
+      });
+    });
+    app.get('/boom', async (_req, res) => {
+      try {
+        await serveCached(res, 'test:boom', 60, async () => {
+          throw new Error('Not found: Table x');
+        });
+      } catch (err: any) {
+        res.status(200).json({ success: true, meta: { note: 'handled' } });
+      }
+    });
+    server = app.listen(0, () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') throw new Error('no port bound');
+      baseUrl = `http://127.0.0.1:${addr.port}`;
+      done();
+    });
+  });
+
+  afterAll((done) => { server.close(done); });
+
+  beforeEach(async () => {
+    produce = jest.fn().mockResolvedValue({ success: true, data: [1, 2, 3] });
+    await cacheService.flush();
+  });
+
+  it('produces once and serves the second request from cache', async () => {
+    const first = await fetch(`${baseUrl}/probe`);
+    expect(first.headers.get('x-cache')).toBe('MISS');
+
+    const second = await fetch(`${baseUrl}/probe`);
+    expect(second.headers.get('x-cache')).toBe('HIT');
+
+    expect(produce).toHaveBeenCalledTimes(1);
+    expect(await second.json()).toEqual({ success: true, data: [1, 2, 3] });
+  });
+
+  it('sets a shared Cache-Control, which outlives the per-instance Map', async () => {
+    const res = await fetch(`${baseUrl}/probe`);
+    expect(res.headers.get('cache-control')).toBe('public, max-age=60');
+  });
+
+  it('serves an oversized body but does not store it', async () => {
+    const first = await fetch(`${baseUrl}/big`);
+    expect(first.status).toBe(200);
+    const second = await fetch(`${baseUrl}/big`);
+    expect(second.headers.get('x-cache')).toBe('MISS');
+    // Produced twice: nothing was retained between the two requests.
+    expect(produce).toHaveBeenCalledTimes(2);
+  });
+
+  it('lets a producer error propagate instead of caching a failure', async () => {
+    const res = await fetch(`${baseUrl}/boom`);
+    const body = await res.json() as any;
+    // The handler's own error branch ran, not a cached empty result.
+    expect(body.meta.note).toBe('handled');
+    expect(await cacheService.get('test:boom')).toBeNull();
+  });
+});

--- a/src/__tests__/football-games.routes.test.ts
+++ b/src/__tests__/football-games.routes.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Tests for the football schedule, scoreboard and game detail endpoints.
+ *
+ * These are the first live-data paths in the football stack, so the cases that matter
+ * are the ones about degrading rather than the happy path: a league with no feed, a
+ * missing key, a tier that does not cover an endpoint, and one panel failing without
+ * taking the page with it.
+ *
+ * Several also pin parameter quirks that cost real debugging time and would silently
+ * regress: /games/teams rejects a bare year+id, /drives cannot be filtered to a game at
+ * all, and only /metrics/wp and /live/plays accept gameId.
+ */
+
+import express from 'express';
+import { Server } from 'http';
+
+jest.mock('@google-cloud/bigquery', () => require('./helpers/bq-mock').factory());
+jest.mock('../utils/logger', () => ({
+  logger: {
+    info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(),
+  },
+}));
+
+// Partial mock: the error classes and predicates stay real so the controller's
+// instanceof checks behave, but the network call is replaced.
+jest.mock('../services/cfbd.service', () => {
+  const actual = jest.requireActual('../services/cfbd.service');
+  return {
+    ...actual,
+    cfbdGet: jest.fn(),
+    hasApiKey: jest.fn(() => true),
+  };
+});
+
+import { mockQuery, rows } from './helpers/bq-mock';
+import * as cfbd from '../services/cfbd.service';
+import { cacheService } from '../services/cache.service';
+import footballRoutes from '../routes/football.routes';
+
+const cfbdGet = cfbd.cfbdGet as jest.Mock;
+const hasApiKey = cfbd.hasApiKey as jest.Mock;
+
+let server: Server;
+let baseUrl: string;
+
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/football', footballRoutes);
+  server = app.listen(0, () => {
+    const addr = server.address();
+    if (!addr || typeof addr === 'string') throw new Error('no port bound');
+    baseUrl = `http://127.0.0.1:${addr.port}`;
+    done();
+  });
+});
+
+afterAll((done) => { server.close(done); });
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+  hasApiKey.mockReturnValue(true);
+  await cacheService.flush();
+});
+
+const get = async (path: string) => {
+  const res = await fetch(`${baseUrl}${path}`);
+  return { status: res.status, body: await res.json() as any };
+};
+
+const boardGame = (over: any = {}) => ({
+  id: 401856766,
+  startDate: '2026-08-29T16:00:00.000Z',
+  status: 'completed',
+  tv: 'ESPN',
+  neutralSite: false,
+  conferenceGame: false,
+  venue: { name: 'Amon G. Carter', city: 'Fort Worth', state: 'TX' },
+  weather: { temperature: 70 },
+  homeTeam: {
+    name: 'TCU Horned Frogs', conference: 'Big 12', classification: 'fbs',
+    points: 10, lineScores: [10, 0, 0, 0],
+  },
+  awayTeam: {
+    name: 'North Carolina Tar Heels', conference: 'ACC', classification: 'fbs',
+    points: 15, lineScores: [10, 2, 3, 0],
+  },
+  ...over,
+});
+
+/** Route cfbdGet by path so a test can describe several feeds at once. */
+function routeCfbd(map: Record<string, any>) {
+  cfbdGet.mockImplementation(async (path: string) => {
+    if (!(path in map)) throw new Error(`unexpected CFBD path ${path}`);
+    const value = map[path];
+    if (value instanceof Error) throw value;
+    return value;
+  });
+}
+
+describe('GET /:sport/scoreboard', () => {
+  it('serves live college games with linescores', async () => {
+    routeCfbd({ '/scoreboard': [boardGame({ status: 'in_progress', period: 2 })] });
+    const { status, body } = await get('/api/football/cfb/scoreboard?season=2026&week=1');
+
+    expect(status).toBe(200);
+    expect(body.meta.count).toBe(1);
+    expect(body.meta.live).toBe(1);
+    expect(body.data[0].home.line_scores).toEqual([10, 0, 0, 0]);
+    expect(body.data[0].game_id).toBe('401856766');
+  });
+
+  it('drops the lower divisions the site does not cover', async () => {
+    // CFBD returns DII and DIII alongside FBS/FCS.
+    routeCfbd({
+      '/scoreboard': [
+        boardGame(),
+        boardGame({
+          id: 999,
+          homeTeam: { name: 'Concord', classification: 'ii', lineScores: [] },
+          awayTeam: { name: 'Charleston (WV)', classification: 'ii', lineScores: [] },
+        }),
+      ],
+    });
+    const { body } = await get('/api/football/cfb/scoreboard');
+    expect(body.data.map((g: any) => g.game_id)).toEqual(['401856766']);
+  });
+
+  it('tells the caller the NFL has no live feed, without calling upstream', async () => {
+    const { status, body } = await get('/api/football/nfl/scoreboard');
+    expect(status).toBe(200);
+    expect(body.data).toEqual([]);
+    expect(body.meta.note).toMatch(/college-only/i);
+    expect(cfbdGet).not.toHaveBeenCalled();
+  });
+
+  it('reports itself unavailable rather than failing when no key is configured', async () => {
+    hasApiKey.mockReturnValue(false);
+    const { status, body } = await get('/api/football/cfb/scoreboard');
+    expect(status).toBe(200);
+    expect(body.meta.note).toMatch(/API key/i);
+    expect(cfbdGet).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a tier restriction as unavailable, not as a 500', async () => {
+    routeCfbd({ '/scoreboard': new cfbd.CfbdNotEntitled('/scoreboard') });
+    const { status, body } = await get('/api/football/cfb/scoreboard');
+    expect(status).toBe(200);
+    expect(body.meta.note).toMatch(/tier does not include/i);
+  });
+
+  it('500s a genuine upstream failure with a generic message', async () => {
+    routeCfbd({ '/scoreboard': new Error('upstream exploded: token abc123') });
+    const { status, body } = await get('/api/football/cfb/scoreboard');
+    expect(status).toBe(500);
+    expect(JSON.stringify(body)).not.toMatch(/abc123/);
+  });
+});
+
+describe('GET /:sport/schedule', () => {
+  const fixture = {
+    id: 401858225, season: 2026, week: 3, seasonType: 'regular',
+    startDate: '2026-09-17T23:30:00.000Z', startTimeTBD: false, completed: false,
+    neutralSite: false, conferenceGame: true, venue: 'Acrisure Stadium',
+    homeTeam: 'Pittsburgh', homeConference: 'ACC', homeClassification: 'fbs',
+    homePoints: null, homePregameElo: 1500,
+    awayTeam: 'Syracuse', awayConference: 'ACC', awayClassification: 'fbs',
+    awayPoints: null, awayPregameElo: 1450,
+    excitementIndex: null,
+  };
+
+  it('returns upcoming fixtures and counts them', async () => {
+    routeCfbd({ '/games': [fixture] });
+    const { status, body } = await get('/api/football/cfb/schedule?season=2026&week=3');
+    expect(status).toBe(200);
+    expect(body.meta.upcoming).toBe(1);
+    expect(body.data[0].home_school).toBe('Pittsburgh');
+    expect(body.data[0].completed).toBe(false);
+  });
+
+  it('warns that its team names are school names, not the BigQuery key', async () => {
+    // /games says "TCU" where /scoreboard and BigQuery say "TCU Horned Frogs", so
+    // anything joining these rows has to join on game_id.
+    routeCfbd({ '/games': [fixture] });
+    const { body } = await get('/api/football/cfb/schedule');
+    expect(body.meta.join_note).toMatch(/game_id/);
+  });
+});
+
+describe('GET /:sport/games/:gameId', () => {
+  const fullFeeds = {
+    '/scoreboard': [boardGame()],
+    '/metrics/wp': [{ playNumber: 1, homeWinProbability: 0.6 }],
+    '/games/teams': [{ id: 401856766, teams: [{ team: 'TCU', points: 10, stats: [] }] }],
+    '/games/players': [{ id: 401856766, teams: [{ team: 'TCU', categories: [] }] }],
+    '/drives': [
+      { gameId: 401856766, driveNumber: 1 },
+      { gameId: 999999, driveNumber: 1 },
+    ],
+  };
+
+  it('assembles every panel and reports which are present', async () => {
+    routeCfbd(fullFeeds);
+    mockQuery.mockResolvedValue(rows([{ week: 1, game_id: '401856766' }]));
+
+    const { status, body } = await get('/api/football/cfb/games/401856766?season=2026');
+    expect(status).toBe(200);
+    expect(body.meta.available).toEqual(
+      expect.arrayContaining(['win_probability', 'team_box', 'player_box', 'drives']),
+    );
+    expect(body.data.game.home.line_scores).toEqual([10, 0, 0, 0]);
+  });
+
+  it('filters drives to this game, since /drives cannot be asked for one', async () => {
+    routeCfbd(fullFeeds);
+    mockQuery.mockResolvedValue(rows([{ week: 1 }]));
+    const { body } = await get('/api/football/cfb/games/401856766?season=2026');
+    expect(body.data.drives).toHaveLength(1);
+    expect(String(body.data.drives[0].gameId)).toBe('401856766');
+  });
+
+  it('passes week and id to the box score, never a bare year+id', async () => {
+    // /games/teams answers "either week, team, or conference are required" otherwise.
+    routeCfbd(fullFeeds);
+    mockQuery.mockResolvedValue(rows([{ week: 1 }]));
+    await get('/api/football/cfb/games/401856766?season=2026&week=1');
+
+    const call = cfbdGet.mock.calls.find((c) => c[0] === '/games/teams');
+    expect(call).toBeDefined();
+    expect(call![1]).toEqual(expect.objectContaining({ week: 1, id: '401856766' }));
+  });
+
+  it('prefers an explicit week over a BigQuery lookup', async () => {
+    routeCfbd(fullFeeds);
+    mockQuery.mockResolvedValue(rows([]));
+    await get('/api/football/cfb/games/401856766?season=2026&week=7');
+
+    // The prediction lookup still runs; what must not is the week lookup.
+    const sql = mockQuery.mock.calls.map((c) => c[0]?.query ?? '');
+    expect(sql.some((q) => /SELECT week/i.test(q))).toBe(false);
+
+    const call = cfbdGet.mock.calls.find((c) => c[0] === '/games/teams');
+    expect(call![1]).toEqual(expect.objectContaining({ week: 7 }));
+  });
+
+  it('explains the week-scoped panels instead of failing when the week is unknown', async () => {
+    routeCfbd({ '/scoreboard': [boardGame()], '/metrics/wp': [{ playNumber: 1 }] });
+    mockQuery.mockResolvedValue(rows([]));   // not in either table
+
+    const { status, body } = await get('/api/football/cfb/games/401856766?season=2026');
+    expect(status).toBe(200);
+    expect(body.meta.week).toBeNull();
+    expect(body.meta.missing).toEqual(
+      expect.arrayContaining(['team_box', 'player_box', 'drives']),
+    );
+    expect(body.meta.notes.team_box).toMatch(/week/i);
+    // The panels that do not need a week still came through.
+    expect(body.meta.available).toContain('win_probability');
+  });
+
+  it('keeps the page up when one panel fails', async () => {
+    routeCfbd({
+      ...fullFeeds,
+      '/games/players': new Error('upstream 503'),
+    });
+    mockQuery.mockResolvedValue(rows([{ week: 1 }]));
+
+    const { status, body } = await get('/api/football/cfb/games/401856766?season=2026');
+    expect(status).toBe(200);
+    expect(body.meta.missing).toContain('player_box');
+    expect(body.meta.notes.player_box).toMatch(/unavailable/i);
+    expect(body.meta.available).toContain('team_box');
+  });
+
+  it('skips the live feed for a finished game', async () => {
+    routeCfbd(fullFeeds);
+    mockQuery.mockResolvedValue(rows([{ week: 1 }]));
+    await get('/api/football/cfb/games/401856766?season=2026');
+    expect(cfbdGet.mock.calls.map((c) => c[0])).not.toContain('/live/plays');
+  });
+
+  it('asks for live plays while a game is in progress', async () => {
+    routeCfbd({
+      ...fullFeeds,
+      '/scoreboard': [boardGame({ status: 'in_progress' })],
+      '/live/plays': [{ playId: 'x' }],
+    });
+    mockQuery.mockResolvedValue(rows([{ week: 1 }]));
+    await get('/api/football/cfb/games/401856766?season=2026');
+    expect(cfbdGet.mock.calls.map((c) => c[0])).toContain('/live/plays');
+  });
+
+  it('rejects a non-numeric game id before doing any work', async () => {
+    const { status, body } = await get('/api/football/cfb/games/DROP-TABLE');
+    expect(status).toBe(400);
+    expect(body.error.code).toBe('BAD_GAME_ID');
+    expect(cfbdGet).not.toHaveBeenCalled();
+  });
+
+  it('404s an id nothing recognises, and does not cache it as a game', async () => {
+    routeCfbd({
+      '/scoreboard': [],
+      '/metrics/wp': [],
+      '/games/teams': [],
+      '/games/players': [],
+      '/drives': [],
+    });
+    mockQuery.mockResolvedValue(rows([]));
+
+    const first = await get('/api/football/cfb/games/123456789?season=2026&week=1');
+    expect(first.status).toBe(404);
+    // A cached 404 would come back as a 200 with an empty body.
+    const second = await get('/api/football/cfb/games/123456789?season=2026&week=1');
+    expect(second.status).toBe(404);
+  });
+
+  it('serves a repeat view from cache', async () => {
+    routeCfbd(fullFeeds);
+    mockQuery.mockResolvedValue(rows([{ week: 1 }]));
+
+    await get('/api/football/cfb/games/401856766?season=2026');
+    const upstreamAfterFirst = cfbdGet.mock.calls.length;
+    await get('/api/football/cfb/games/401856766?season=2026');
+
+    expect(cfbdGet.mock.calls.length).toBe(upstreamAfterFirst);
+  });
+});

--- a/src/__tests__/football-stats.routes.test.ts
+++ b/src/__tests__/football-stats.routes.test.ts
@@ -31,6 +31,7 @@ import {
   mockQuery, rows, count, queue, sentQueries, sentParams,
 } from './helpers/bq-mock';
 import footballRoutes from '../routes/football.routes';
+import { cacheService } from '../services/cache.service';
 
 let server: Server;
 let baseUrl: string;
@@ -48,7 +49,12 @@ beforeAll((done) => {
 });
 
 afterAll((done) => { server.close(done); });
-beforeEach(() => { jest.clearAllMocks(); });
+// The response cache is process-wide and these tests reuse query strings, so without a
+// flush the second identical request is served from cache and never reaches the mock.
+beforeEach(async () => {
+  jest.clearAllMocks();
+  await cacheService.flush();
+});
 
 const get = async (path: string) => {
   const res = await fetch(`${baseUrl}${path}`);

--- a/src/__tests__/football-stats.routes.test.ts
+++ b/src/__tests__/football-stats.routes.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Tests for the football stats endpoints.
+ *
+ * The first football tests in this repo. They pin the conventions rather than the
+ * numbers: the three-tier error contract, the ORDER BY allow-list that is the only thing
+ * between a query string and interpolated SQL, and the meta.columns contract the frontend
+ * renders from.
+ *
+ * Two of these are direct regression tests for defects found in production:
+ *   - `week` on the season endpoint used to reach SQL and 500 on `Unrecognized name`.
+ *   - the CFB per-week note claimed no college stats existed while 154 columns of them
+ *     sat in BigQuery.
+ *
+ * No supertest — it is not a dependency here. The router is mounted on a bare express app
+ * and driven over a real ephemeral port with global fetch, matching
+ * transactions.routes.test.ts. src/app.ts is never imported: it calls app.listen and
+ * starts the scheduler at import time.
+ */
+
+import express from 'express';
+import { Server } from 'http';
+
+jest.mock('@google-cloud/bigquery', () => require('./helpers/bq-mock').factory());
+jest.mock('../utils/logger', () => ({
+  logger: {
+    info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(),
+  },
+}));
+
+import {
+  mockQuery, rows, count, queue, sentQueries, sentParams,
+} from './helpers/bq-mock';
+import footballRoutes from '../routes/football.routes';
+
+let server: Server;
+let baseUrl: string;
+
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/football', footballRoutes);
+  server = app.listen(0, () => {
+    const addr = server.address();
+    if (!addr || typeof addr === 'string') throw new Error('no port bound');
+    baseUrl = `http://127.0.0.1:${addr.port}`;
+    done();
+  });
+});
+
+afterAll((done) => { server.close(done); });
+beforeEach(() => { jest.clearAllMocks(); });
+
+const get = async (path: string) => {
+  const res = await fetch(`${baseUrl}${path}`);
+  return { status: res.status, body: await res.json() as any };
+};
+
+describe('GET /:sport/stats/teams/season', () => {
+  const sampleRow = {
+    season: 2025, team: 'Ohio State Buckeyes', team_abbr: 'OSU',
+    gamesPlayed: 16, totalPointsPerGame: 35.5,
+  };
+
+  it('serves the college season table and describes its columns', async () => {
+    queue(rows([sampleRow]), count(136));
+    const { status, body } = await get(
+      '/api/football/cfb/stats/teams/season?season=2025',
+    );
+
+    expect(status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.data).toHaveLength(1);
+    expect(body.meta.scope).toBe('season');
+    expect(body.meta.total).toBe(136);
+    expect(Array.isArray(body.meta.columns)).toBe(true);
+    expect(body.meta.columns.length).toBeGreaterThan(0);
+    expect(body.meta.columns[0]).toEqual(
+      expect.objectContaining({
+        key: expect.any(String),
+        label: expect.any(String),
+        group: expect.any(String),
+        format: expect.any(String),
+      }),
+    );
+  });
+
+  it('states that the college table covers FBS only', async () => {
+    queue(rows([sampleRow]), count(136));
+    const { body } = await get('/api/football/cfb/stats/teams/season');
+    expect(body.meta.coverage).toMatch(/FBS only/i);
+  });
+
+  it('ignores week and division instead of 500ing on Unrecognized name', async () => {
+    // Regression: cfb_season.team_season_stats has neither column. Passing them through
+    // raised `Unrecognized name: week`, which the old error guard did not match, so it
+    // fell through to a 500.
+    queue(rows([sampleRow]), count(136));
+    const { status, body } = await get(
+      '/api/football/cfb/stats/teams/season?week=5&division=fbs',
+    );
+
+    expect(status).toBe(200);
+    expect(body.meta.ignored_params).toEqual(['week', 'division']);
+    for (const sql of sentQueries()) {
+      expect(sql).not.toMatch(/\bweek\b/);
+      expect(sql).not.toMatch(/\bdivision\b/);
+    }
+  });
+
+  it('rejects an off-list sort without touching BigQuery', async () => {
+    const { status, body } = await get(
+      '/api/football/cfb/stats/teams/season?sort=totalYards%3B+DROP+TABLE',
+    );
+    expect(status).toBe(400);
+    expect(body.error.code).toBe('INVALID_SORT');
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it('narrows the projection to the requested group', async () => {
+    queue(rows([sampleRow]), count(136));
+    await get('/api/football/cfb/stats/teams/season?group=passing');
+    const select = sentQueries()[0];
+    expect(select).toMatch(/`passingYards`/);
+    // A kicking column must not ride along in a passing-only request.
+    expect(select).not.toMatch(/`fieldGoalsMade`/);
+  });
+
+  it('reports an unknown field rather than silently dropping it', async () => {
+    queue(rows([sampleRow]), count(136));
+    const { body } = await get(
+      '/api/football/cfb/stats/teams/season?fields=passingYards,nonsense',
+    );
+    expect(body.meta.unknown_fields).toEqual(['nonsense']);
+  });
+
+  it('caps limit at 200 however large the request', async () => {
+    queue(rows([sampleRow]), count(136));
+    await get('/api/football/cfb/stats/teams/season?limit=99999');
+    expect(sentParams(0).limit).toBe(200);
+  });
+
+  it('answers 200 with a note where the sport has no season table', async () => {
+    const { status, body } = await get('/api/football/nfl/stats/teams/season');
+    expect(status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.data).toEqual([]);
+    expect(body.meta.note).toMatch(/season stats/i);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it('treats a missing table as an expected state, not a failure', async () => {
+    mockQuery.mockRejectedValue(
+      new Error('Not found: Table hankstank:cfb_season.team_season_stats'),
+    );
+    const { status, body } = await get('/api/football/cfb/stats/teams/season');
+    expect(status).toBe(200);
+    expect(body.meta.note).toMatch(/not built yet/i);
+  });
+
+  it('does not leak the underlying error message on a real failure', async () => {
+    mockQuery.mockRejectedValue(
+      new Error('quota exceeded for project hankstank, billing account 01ABCD'),
+    );
+    const { status, body } = await get('/api/football/cfb/stats/teams/season');
+    expect(status).toBe(500);
+    expect(body.error.code).toBe('STATS_ERROR');
+    expect(JSON.stringify(body)).not.toMatch(/quota|billing|01ABCD/i);
+  });
+
+  it('404s an unknown sport before querying anything', async () => {
+    const { status, body } = await get('/api/football/xfl/stats/teams/season');
+    expect(status).toBe(404);
+    expect(body.error.code).toBe('UNKNOWN_SPORT');
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /:sport/stats/teams (per week)', () => {
+  it('points at the season endpoint instead of denying college stats exist', async () => {
+    // Regression: this note used to read "No per-team advanced stats feed for this sport
+    // yet" while the college season table was already populated and configured.
+    const { status, body } = await get('/api/football/cfb/stats/teams');
+    expect(status).toBe(200);
+    expect(body.meta.season_endpoint).toBe(
+      '/api/football/cfb/stats/teams/season',
+    );
+    expect(body.meta.note).toContain('/api/football/cfb/stats/teams/season');
+    expect(body.meta.note).not.toMatch(/no per-team advanced stats feed/i);
+  });
+
+  it('carries the same scope and columns contract as the season endpoint', async () => {
+    queue(rows([{ season: 2025, week: 1, team: 'PHI', off_epa_play: 0.12 }]), count(32));
+    const { body } = await get('/api/football/nfl/stats/teams?season=2025');
+    expect(body.meta.scope).toBe('week');
+    expect(body.meta.columns.length).toBe(17);
+  });
+
+  it('marks defensive EPA as lower-is-better', async () => {
+    queue(rows([{ season: 2025, week: 1, team: 'PHI' }]), count(32));
+    const { body } = await get('/api/football/nfl/stats/teams');
+    const def = body.meta.columns.find((c: any) => c.key === 'def_epa_play');
+    expect(def.higher_is_better).toBe(false);
+    const off = body.meta.columns.find((c: any) => c.key === 'off_epa_play');
+    expect(off.higher_is_better).toBe(true);
+  });
+});
+
+describe('GET /:sport/teams', () => {
+  const nflRow = {
+    team_abbr: 'PHI', team_name: 'Philadelphia Eagles', team_nick: 'Eagles',
+    team_conf: 'NFC', team_division: 'NFC East',
+    team_color: '#004C54', team_color2: '#A5ACAF',
+    team_logo_espn: 'https://example.test/phi.png',
+    team_logo_squared: 'https://example.test/phi-sq.png',
+    team_wordmark: 'https://example.test/phi-wm.png',
+  };
+
+  it('returns a canonical row with colours, logo and aliases', async () => {
+    queue(rows([nflRow]));
+    const { status, body } = await get('/api/football/nfl/teams');
+    expect(status).toBe(200);
+    expect(body.data[0]).toEqual(
+      expect.objectContaining({
+        key: 'PHI',
+        abbr: 'PHI',
+        name: 'Philadelphia Eagles',
+        primary_color: '#004C54',
+        logo: 'https://example.test/phi.png',
+      }),
+    );
+    // One matcher in one place: the other football tables disagree on team naming.
+    expect(body.data[0].aliases).toEqual(
+      expect.arrayContaining(['PHI', 'Philadelphia Eagles', 'Eagles']),
+    );
+  });
+
+  it('restricts to the current league by default', async () => {
+    // nfl_historical.teams holds 36 rows for 32 clubs: OAK, SD and STL persist.
+    queue(rows([nflRow]));
+    await get('/api/football/nfl/teams');
+    expect(sentQueries()[0]).toMatch(/team_abbr IN \(/);
+  });
+
+  it('can be asked for the full historical set', async () => {
+    queue(rows([nflRow]));
+    const { body } = await get('/api/football/nfl/teams?active=false');
+    expect(body.meta.active).toBe(false);
+    expect(sentQueries()[0]).not.toMatch(/team_abbr IN \(/);
+  });
+
+  it('answers 200 with a note where the sport has no teams table', async () => {
+    const { status, body } = await get('/api/football/cfb/teams');
+    expect(status).toBe(200);
+    expect(body.data).toEqual([]);
+    expect(body.meta.note).toMatch(/team metadata/i);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/football-stats.routes.test.ts
+++ b/src/__tests__/football-stats.routes.test.ts
@@ -182,16 +182,42 @@ describe('GET /:sport/stats/teams/season', () => {
 });
 
 describe('GET /:sport/stats/teams (per week)', () => {
-  it('points at the season endpoint instead of denying college stats exist', async () => {
-    // Regression: this note used to read "No per-team advanced stats feed for this sport
-    // yet" while the college season table was already populated and configured.
-    const { status, body } = await get('/api/football/cfb/stats/teams');
+  it('serves college per-game advanced stats, aliased onto the shared names', async () => {
+    // This used to answer with a note claiming college had no per-team stats feed.
+    // It now serves CollegeFootballData's per-game advanced table, aliased in SQL onto
+    // the same canonical keys the NFL table uses — which is what lets one client table
+    // render both sports.
+    queue(rows([{
+      season: 2025, week: 3, team: 'Ohio State Buckeyes', opponent: 'Ohio',
+      off_epa_play: 0.41, def_epa_play: 0.02,
+    }]), count(3316));
+
+    const { status, body } = await get('/api/football/cfb/stats/teams?season=2025');
     expect(status).toBe(200);
-    expect(body.meta.season_endpoint).toBe(
-      '/api/football/cfb/stats/teams/season',
+    expect(body.meta.scope).toBe('week');
+    expect(body.data[0].off_epa_play).toBe(0.41);
+
+    // The physical column is CFBD's `ppa`; the client only ever sees the canonical key.
+    const sql = sentQueries()[0];
+    expect(sql).toMatch(/`ppa` AS `off_epa_play`/);
+    expect(sql).toMatch(/`opp_ppa` AS `def_epa_play`/);
+  });
+
+  it('orders by the physical column while validating the canonical one', async () => {
+    // The allow-list guards the canonical name; the interpolated identifier is the
+    // physical one, so neither is ever caller-controlled.
+    queue(rows([{ season: 2025, week: 1, team: 'X' }]), count(1));
+    await get('/api/football/cfb/stats/teams?sort=off_epa_play&direction=desc');
+    expect(sentQueries()[0]).toMatch(/ORDER BY `ppa` DESC/);
+  });
+
+  it('still rejects an off-list sort for college', async () => {
+    const { status, body } = await get(
+      '/api/football/cfb/stats/teams?sort=ppa%3B+DROP',
     );
-    expect(body.meta.note).toContain('/api/football/cfb/stats/teams/season');
-    expect(body.meta.note).not.toMatch(/no per-team advanced stats feed/i);
+    expect(status).toBe(400);
+    expect(body.error.code).toBe('INVALID_SORT');
+    expect(mockQuery).not.toHaveBeenCalled();
   });
 
   it('carries the same scope and columns contract as the season endpoint', async () => {

--- a/src/__tests__/helpers/bq-mock.ts
+++ b/src/__tests__/helpers/bq-mock.ts
@@ -55,3 +55,15 @@ export function sentQueries(): string[] {
 export function sentParams(n = 0): Record<string, any> {
   return mockQuery.mock.calls[n]?.[0]?.params ?? {};
 }
+
+/**
+ * The params of the first call whose SQL matches `pattern`.
+ *
+ * Preferred over indexing by call position: a handler that gains a query — a
+ * permission check, a migration step — should not break an assertion about a
+ * different one.
+ */
+export function sentParamsFor(pattern: RegExp): Record<string, any> {
+  const call = mockQuery.mock.calls.find((c) => pattern.test(c[0]?.query ?? ''));
+  return call?.[0]?.params ?? {};
+}

--- a/src/__tests__/helpers/bq-mock.ts
+++ b/src/__tests__/helpers/bq-mock.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared BigQuery mock for the football controller tests.
+ *
+ * Not named *.test.ts on purpose — jest's testMatch would collect it as a suite.
+ *
+ * The controllers build `new BigQuery(...)` at module scope, so this has to be applied
+ * with a hoisted jest.mock factory before the controller is imported. Callers do:
+ *
+ *     jest.mock('@google-cloud/bigquery', () => require('./helpers/bq-mock').factory());
+ *     import { mockQuery } from './helpers/bq-mock';
+ *
+ * SHAPE CONTRACT — the thing that will cost you an hour if you get it wrong. Handlers
+ * destructure results as:
+ *
+ *     const [rows] = await bigquery.query(...)          -> resolve [ [ {...} ] ]
+ *     const [[{ total }]] = await bigquery.query(...)   -> resolve [ [ { total: 1 } ] ]
+ *
+ * So a resolved value is ALWAYS an array whose first element is the row array. Use the
+ * `rows()` and `count()` helpers below rather than hand-nesting it.
+ */
+
+export const mockQuery: jest.Mock = jest.fn();
+
+/** Pass to jest.mock's factory to stand in for the @google-cloud/bigquery module. */
+export function factory() {
+  return {
+    BigQuery: jest.fn().mockImplementation(() => ({ query: mockQuery })),
+  };
+}
+
+/** A row-returning result. */
+export function rows(values: any[]): [any[]] {
+  return [values];
+}
+
+/** A COUNT(*) AS total result. */
+export function count(total: number): [Array<{ total: number }>] {
+  return [[{ total }]];
+}
+
+/**
+ * Queue results in the order the handler will ask for them. Most handlers issue the page
+ * query first and the count second.
+ */
+export function queue(...results: any[][]): void {
+  for (const r of results) mockQuery.mockResolvedValueOnce(r as any);
+}
+
+/** Every SQL string the handler sent, for asserting on projection and ORDER BY. */
+export function sentQueries(): string[] {
+  return mockQuery.mock.calls.map((c) => c[0]?.query ?? '');
+}
+
+/** The params object of the nth call. */
+export function sentParams(n = 0): Record<string, any> {
+  return mockQuery.mock.calls[n]?.[0]?.params ?? {};
+}

--- a/src/__tests__/pickem.routes.test.ts
+++ b/src/__tests__/pickem.routes.test.ts
@@ -52,7 +52,7 @@ jest.mock('../middleware/auth.middleware', () => {
   };
 });
 
-import { mockQuery, rows, sentQueries, sentParams } from './helpers/bq-mock';
+import { mockQuery, rows, sentQueries, sentParamsFor } from './helpers/bq-mock';
 import pickemRoutes from '../routes/pickem.routes';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const authMock = require('../middleware/auth.middleware');
@@ -170,8 +170,9 @@ describe('PUT /picks', () => {
   it('saves a valid pick as a side, never as a team name', async () => {
     mockQuery
       .mockResolvedValueOnce(rows([{ game_id: 'g1', spread_line: -2.5, locked: false }]))
-      .mockResolvedValueOnce(rows([]))   // user upsert
-      .mockResolvedValueOnce(rows([]));  // picks upsert
+      .mockResolvedValueOnce(rows([{ n: 0 }]))  // adoption: nothing to claim
+      .mockResolvedValueOnce(rows([]))          // user upsert
+      .mockResolvedValueOnce(rows([]));         // picks upsert
 
     const { status, body: res } = await call('/api/pickem/picks',
       body([{ game_id: 'g1', pick_type: 'ats', selected: 'away' }]));
@@ -179,9 +180,7 @@ describe('PUT /picks', () => {
     expect(status).toBe(200);
     expect(res.data.accepted).toBe(1);
     // The stored value is a side. A team name would be a pick that a rename can orphan.
-    const merge = sentQueries().find((q) => /MERGE .*picks/s.test(q));
-    expect(merge).toBeDefined();
-    const params = sentParams(2);
+    const params = sentParamsFor(/MERGE .*picks/s);
     expect(params.selected0).toBe('away');
     expect(params.pickId0).toBe('sub-123|g1|ats');
   });
@@ -206,6 +205,7 @@ describe('PUT /picks', () => {
         { game_id: 'g1', spread_line: -2.5, locked: true },
         { game_id: 'g2', spread_line: 3.0, locked: false },
       ]))
+      .mockResolvedValueOnce(rows([{ n: 0 }]))  // adoption
       .mockResolvedValueOnce(rows([]))
       .mockResolvedValueOnce(rows([]));
 
@@ -231,6 +231,7 @@ describe('PUT /picks', () => {
   it('allows a straight-up pick on a game with no line', async () => {
     mockQuery
       .mockResolvedValueOnce(rows([{ game_id: 'g1', spread_line: null, locked: false }]))
+      .mockResolvedValueOnce(rows([{ n: 0 }]))  // adoption
       .mockResolvedValueOnce(rows([]))
       .mockResolvedValueOnce(rows([]));
     const { body: res } = await call('/api/pickem/picks',
@@ -306,6 +307,7 @@ describe('GET /leaderboard', () => {
 
 describe('GET /me', () => {
   it('returns a record with pushes and pending counted separately', async () => {
+    mockQuery.mockResolvedValueOnce(rows([{ n: 0 }]));  // adoption check
     mockQuery.mockResolvedValueOnce(rows([
       { is_correct: true, is_push: false, kickoff: { value: '2026-09-13T17:00:00Z' } },
       { is_correct: false, is_push: false, kickoff: { value: '2026-09-13T17:00:00Z' } },
@@ -321,5 +323,36 @@ describe('GET /me', () => {
   it('requires a signed-in user', async () => {
     const { status } = await call('/api/pickem/me');
     expect(status).toBe(401);
+  });
+});
+
+describe('adopting imported picks', () => {
+  it('claims spreadsheet picks on first sign-in, matching the verified email', async () => {
+    // The contest ran in a spreadsheet first, so those picks were imported against
+    // "email:<address>" and have no Google subject to key on.
+    mockQuery
+      .mockResolvedValueOnce(rows([{ n: 99 }]))  // 99 rows waiting to be claimed
+      .mockResolvedValueOnce(rows([]))           // UPDATE
+      .mockResolvedValueOnce(rows([]))           // DELETE leftover picks
+      .mockResolvedValueOnce(rows([]))           // DELETE provisional user
+      .mockResolvedValueOnce(rows([]));          // the actual /me query
+
+    const { status } = await call('/api/pickem/me?season=2026', signedIn);
+    expect(status).toBe(200);
+
+    const update = sentQueries().find((q) => /UPDATE .*picks/s.test(q));
+    expect(update).toBeDefined();
+    // pick_id embeds the user, so taking ownership must rewrite both.
+    expect(update).toMatch(/pick_id = CONCAT/);
+    expect(sentParamsFor(/UPDATE .*picks/s).provisional)
+      .toBe('email:picker@example.invalid');
+  });
+
+  it('does nothing when there is nothing to claim', async () => {
+    mockQuery
+      .mockResolvedValueOnce(rows([{ n: 0 }]))
+      .mockResolvedValueOnce(rows([]));
+    await call('/api/pickem/me?season=2026', signedIn);
+    expect(sentQueries().some((q) => /UPDATE .*picks/s.test(q))).toBe(false);
   });
 });

--- a/src/__tests__/pickem.routes.test.ts
+++ b/src/__tests__/pickem.routes.test.ts
@@ -27,6 +27,10 @@ jest.mock('../middleware/auth.middleware', () => {
     ...actual,
     __setConfigured: (v: boolean) => { configured = v; },
     isAuthConfigured: () => configured,
+    // Mocked so the test never reaches real Secret Manager. It passed locally only
+    // because a developer machine has application-default credentials; CI has none,
+    // and a unit test should not be calling a cloud service either way.
+    googleClientId: async () => (configured ? 'test-client-id.apps.googleusercontent.com' : null),
     attachUser: (req: any, _res: any, next: any) => {
       if (req.headers.authorization === 'Bearer good') req.user = USER;
       next();
@@ -102,10 +106,18 @@ describe('GET /config', () => {
     const { status, body } = await call('/api/pickem/config');
     expect(status).toBe(200);
     expect(body.data).toEqual(expect.objectContaining({
-      auth_configured: expect.any(Boolean),
+      auth_configured: true,
+      google_client_id: 'test-client-id.apps.googleusercontent.com',
       sports: ['nfl', 'cfb'],
       pick_types: ['ats', 'su'],
     }));
+  });
+
+  it('reports sign-in unavailable when no client id is configured', async () => {
+    authMock.__setConfigured(false);
+    const { body } = await call('/api/pickem/config');
+    expect(body.data.auth_configured).toBe(false);
+    expect(body.data.google_client_id).toBeNull();
   });
 });
 

--- a/src/__tests__/pickem.routes.test.ts
+++ b/src/__tests__/pickem.routes.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Tests for the pick'em contest endpoints.
+ *
+ * The cases that matter are the ones a client must not be trusted with: the kickoff
+ * lock, and the fact that a pick records a side rather than a team name. Both are
+ * enforced server-side, and both are the kind of rule that quietly stops working.
+ */
+
+import express from 'express';
+import { Server } from 'http';
+
+jest.mock('@google-cloud/bigquery', () => require('./helpers/bq-mock').factory());
+jest.mock('../utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+// Stand in for Google token verification. A token of 'good' is a signed-in user;
+// anything else is anonymous.
+jest.mock('../middleware/auth.middleware', () => {
+  const actual = jest.requireActual('../middleware/auth.middleware');
+  const USER = {
+    userId: 'sub-123', email: 'picker@example.invalid',
+    displayName: 'Picker', pictureUrl: null,
+  };
+  let configured = true;
+  return {
+    ...actual,
+    __setConfigured: (v: boolean) => { configured = v; },
+    isAuthConfigured: () => configured,
+    attachUser: (req: any, _res: any, next: any) => {
+      if (req.headers.authorization === 'Bearer good') req.user = USER;
+      next();
+    },
+    requireUser: (req: any, res: any, next: any) => {
+      if (!configured) {
+        res.status(503).json({
+          success: false,
+          error: { code: 'AUTH_NOT_CONFIGURED', message: 'not configured' },
+        });
+        return;
+      }
+      if (req.headers.authorization !== 'Bearer good') {
+        res.status(401).json({
+          success: false,
+          error: { code: 'SIGN_IN_REQUIRED', message: 'sign in' },
+        });
+        return;
+      }
+      req.user = USER;
+      next();
+    },
+  };
+});
+
+import { mockQuery, rows, sentQueries, sentParams } from './helpers/bq-mock';
+import pickemRoutes from '../routes/pickem.routes';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const authMock = require('../middleware/auth.middleware');
+
+let server: Server;
+let baseUrl: string;
+
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/pickem', pickemRoutes);
+  server = app.listen(0, () => {
+    const addr = server.address();
+    if (!addr || typeof addr === 'string') throw new Error('no port bound');
+    baseUrl = `http://127.0.0.1:${addr.port}`;
+    done();
+  });
+});
+afterAll((done) => { server.close(done); });
+beforeEach(() => {
+  jest.clearAllMocks();
+  authMock.__setConfigured(true);
+});
+
+async function call(path: string, init: any = {}) {
+  const res = await fetch(`${baseUrl}${path}`, init);
+  return { status: res.status, body: await res.json() as any };
+}
+const signedIn = { headers: { Authorization: 'Bearer good' } };
+
+const game = (over: any = {}) => ({
+  game_id: 'g1', sport: 'nfl', division: null, season: 2026, week: 1,
+  kickoff: { value: '2026-09-13T17:00:00.000Z' }, start_time_tbd: false,
+  home_team: 'CAR', away_team: 'CHI',
+  home_display: 'Carolina Panthers', away_display: 'Chicago Bears',
+  home_conference: null, away_conference: null, neutral_site: false,
+  spread_line: -2.5, total_line: 44.5,
+  home_score: null, away_score: null, completed: false, locked: false,
+  ...over,
+});
+
+describe('GET /config', () => {
+  it('reports whether sign-in is available, so the UI can say so', async () => {
+    const { status, body } = await call('/api/pickem/config');
+    expect(status).toBe(200);
+    expect(body.data).toEqual(expect.objectContaining({
+      auth_configured: expect.any(Boolean),
+      sports: ['nfl', 'cfb'],
+      pick_types: ['ats', 'su'],
+    }));
+  });
+});
+
+describe('GET /games', () => {
+  it('serves the week and lists the weeks that exist', async () => {
+    mockQuery
+      .mockResolvedValueOnce(rows([game()]))          // games
+      .mockResolvedValueOnce(rows([{ week: 1 }, { week: 2 }]));  // weeks
+
+    const { status, body } = await call('/api/pickem/games?sport=nfl&week=1');
+    expect(status).toBe(200);
+    expect(body.meta.weeks).toEqual([1, 2]);
+    expect(body.meta.signed_in).toBe(false);
+    expect(body.data[0].kickoff).toBe('2026-09-13T17:00:00.000Z');
+  });
+
+  it('computes the lock in SQL, not from a client clock', async () => {
+    mockQuery.mockResolvedValueOnce(rows([game()])).mockResolvedValueOnce(rows([]));
+    await call('/api/pickem/games?sport=nfl&week=1');
+    // The lock has to come from the server's own clock; a client-supplied time is
+    // not evidence that a game has not started.
+    expect(sentQueries()[0]).toMatch(/kickoff <= CURRENT_TIMESTAMP\(\)/);
+  });
+
+  it('defaults to the first week with an unplayed game', async () => {
+    mockQuery
+      .mockResolvedValueOnce(rows([{ week: 3 }]))     // week probe
+      .mockResolvedValueOnce(rows([game({ week: 3 })]))
+      .mockResolvedValueOnce(rows([{ week: 3 }]));
+    const { body } = await call('/api/pickem/games?sport=nfl');
+    expect(body.meta.week).toBe(3);
+    expect(sentQueries()[0]).toMatch(/NOT completed/);
+  });
+
+  it("merges a signed-in user's own picks into the same response", async () => {
+    mockQuery
+      .mockResolvedValueOnce(rows([game()]))
+      .mockResolvedValueOnce(rows([{ week: 1 }]))
+      .mockResolvedValueOnce(rows([{
+        game_id: 'g1', pick_type: 'ats', selected: 'away',
+        spread_at_pick: -2.5, updated_at: { value: '2026-09-01T00:00:00Z' },
+      }]));
+    const { body } = await call('/api/pickem/games?sport=nfl&week=1', signedIn);
+    expect(body.meta.signed_in).toBe(true);
+    expect(body.meta.picks[0]).toEqual(expect.objectContaining({
+      game_id: 'g1', selected: 'away',
+    }));
+  });
+
+  it('rejects an unknown sport', async () => {
+    const { status, body } = await call('/api/pickem/games?sport=xfl');
+    expect(status).toBe(400);
+    expect(body.error.code).toBe('UNKNOWN_SPORT');
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+});
+
+describe('PUT /picks', () => {
+  const body = (picks: any[]) => ({
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', Authorization: 'Bearer good' },
+    body: JSON.stringify({ sport: 'nfl', season: 2026, week: 1, picks }),
+  });
+
+  it('saves a valid pick as a side, never as a team name', async () => {
+    mockQuery
+      .mockResolvedValueOnce(rows([{ game_id: 'g1', spread_line: -2.5, locked: false }]))
+      .mockResolvedValueOnce(rows([]))   // user upsert
+      .mockResolvedValueOnce(rows([]));  // picks upsert
+
+    const { status, body: res } = await call('/api/pickem/picks',
+      body([{ game_id: 'g1', pick_type: 'ats', selected: 'away' }]));
+
+    expect(status).toBe(200);
+    expect(res.data.accepted).toBe(1);
+    // The stored value is a side. A team name would be a pick that a rename can orphan.
+    const merge = sentQueries().find((q) => /MERGE .*picks/s.test(q));
+    expect(merge).toBeDefined();
+    const params = sentParams(2);
+    expect(params.selected0).toBe('away');
+    expect(params.pickId0).toBe('sub-123|g1|ats');
+  });
+
+  it('refuses a game that has kicked off, and says which', async () => {
+    mockQuery.mockResolvedValueOnce(
+      rows([{ game_id: 'g1', spread_line: -2.5, locked: true }]),
+    );
+    const { body: res } = await call('/api/pickem/picks',
+      body([{ game_id: 'g1', pick_type: 'ats', selected: 'away' }]));
+
+    expect(res.data.accepted).toBe(0);
+    expect(res.data.rejected).toEqual([{ game_id: 'g1', reason: 'kicked off' }]);
+    // Nothing was written.
+    expect(sentQueries().some((q) => /MERGE/.test(q))).toBe(false);
+  });
+
+  it('saves the open games in a sheet where one has already started', async () => {
+    // Partial success is the normal mid-week case, not a failure.
+    mockQuery
+      .mockResolvedValueOnce(rows([
+        { game_id: 'g1', spread_line: -2.5, locked: true },
+        { game_id: 'g2', spread_line: 3.0, locked: false },
+      ]))
+      .mockResolvedValueOnce(rows([]))
+      .mockResolvedValueOnce(rows([]));
+
+    const { body: res } = await call('/api/pickem/picks', body([
+      { game_id: 'g1', pick_type: 'ats', selected: 'home' },
+      { game_id: 'g2', pick_type: 'ats', selected: 'away' },
+    ]));
+    expect(res.data.accepted).toBe(1);
+    expect(res.data.rejected).toHaveLength(1);
+  });
+
+  it('refuses an ATS pick on a game with no posted line', async () => {
+    mockQuery.mockResolvedValueOnce(
+      rows([{ game_id: 'g1', spread_line: null, locked: false }]),
+    );
+    const { body: res } = await call('/api/pickem/picks',
+      body([{ game_id: 'g1', pick_type: 'ats', selected: 'home' }]));
+    expect(res.data.rejected).toEqual([
+      { game_id: 'g1', reason: 'no spread posted' },
+    ]);
+  });
+
+  it('allows a straight-up pick on a game with no line', async () => {
+    mockQuery
+      .mockResolvedValueOnce(rows([{ game_id: 'g1', spread_line: null, locked: false }]))
+      .mockResolvedValueOnce(rows([]))
+      .mockResolvedValueOnce(rows([]));
+    const { body: res } = await call('/api/pickem/picks',
+      body([{ game_id: 'g1', pick_type: 'su', selected: 'home' }]));
+    expect(res.data.accepted).toBe(1);
+  });
+
+  it('refuses a game that is not in the stated week', async () => {
+    mockQuery.mockResolvedValueOnce(rows([]));
+    const { body: res } = await call('/api/pickem/picks',
+      body([{ game_id: 'nope', pick_type: 'su', selected: 'home' }]));
+    expect(res.data.rejected).toEqual([
+      { game_id: 'nope', reason: 'not in this week' },
+    ]);
+  });
+
+  it('validates the body before querying anything', async () => {
+    const { status, body: res } = await call('/api/pickem/picks',
+      body([{ game_id: 'g1', pick_type: 'parlay', selected: 'home' }]));
+    expect(status).toBe(400);
+    expect(res.error.code).toBe('BAD_PICK');
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it('requires a signed-in user', async () => {
+    const { status, body: res } = await call('/api/pickem/picks', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sport: 'nfl', season: 2026, week: 1, picks: [] }),
+    });
+    expect(status).toBe(401);
+    expect(res.error.code).toBe('SIGN_IN_REQUIRED');
+  });
+
+  it('says it is the server that is unconfigured, not the caller', async () => {
+    authMock.__setConfigured(false);
+    const { status, body: res } = await call('/api/pickem/picks', body([]));
+    expect(status).toBe(503);
+    expect(res.error.code).toBe('AUTH_NOT_CONFIGURED');
+  });
+});
+
+describe('GET /leaderboard', () => {
+  it('is public and ranks by wins', async () => {
+    mockQuery.mockResolvedValueOnce(rows([
+      { user_id: 'a', display_name: 'A', wins: 9, losses: 1, win_pct: 0.9 },
+      { user_id: 'b', display_name: 'B', wins: 7, losses: 3, win_pct: 0.7 },
+    ]));
+    const { status, body } = await call(
+      '/api/pickem/leaderboard?sport=nfl&pick_type=ats',
+    );
+    expect(status).toBe(200);
+    expect(body.data[0].rank).toBe(1);
+    expect(body.meta.scope).toBe('season');
+    expect(sentQueries()[0]).toMatch(/ORDER BY wins DESC/);
+  });
+
+  it('reads the weekly view when a week is given', async () => {
+    mockQuery.mockResolvedValueOnce(rows([]));
+    const { body } = await call('/api/pickem/leaderboard?sport=nfl&week=2');
+    expect(body.meta.scope).toBe('week');
+    expect(sentQueries()[0]).toMatch(/leaderboard_weekly/);
+  });
+
+  it('rejects a bad pick type', async () => {
+    const { status, body } = await call(
+      '/api/pickem/leaderboard?sport=nfl&pick_type=teaser',
+    );
+    expect(status).toBe(400);
+    expect(body.error.code).toBe('BAD_PICK_TYPE');
+  });
+});
+
+describe('GET /me', () => {
+  it('returns a record with pushes and pending counted separately', async () => {
+    mockQuery.mockResolvedValueOnce(rows([
+      { is_correct: true, is_push: false, kickoff: { value: '2026-09-13T17:00:00Z' } },
+      { is_correct: false, is_push: false, kickoff: { value: '2026-09-13T17:00:00Z' } },
+      { is_correct: null, is_push: true, kickoff: { value: '2026-09-13T17:00:00Z' } },
+      { is_correct: null, is_push: false, kickoff: { value: '2026-09-20T17:00:00Z' } },
+    ]));
+    const { status, body } = await call('/api/pickem/me?season=2026', signedIn);
+    expect(status).toBe(200);
+    // A push is not a loss and an ungraded pick is not a loss either.
+    expect(body.meta.record).toEqual({ wins: 1, losses: 1, pushes: 1, pending: 1 });
+  });
+
+  it('requires a signed-in user', async () => {
+    const { status } = await call('/api/pickem/me');
+    expect(status).toBe(401);
+  });
+});

--- a/src/__tests__/pickem.routes.test.ts
+++ b/src/__tests__/pickem.routes.test.ts
@@ -54,6 +54,7 @@ jest.mock('../middleware/auth.middleware', () => {
 
 import { mockQuery, rows, sentQueries, sentParamsFor } from './helpers/bq-mock';
 import pickemRoutes from '../routes/pickem.routes';
+import { __resetAdoptionMemo } from '../controllers/pickem.controller';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const authMock = require('../middleware/auth.middleware');
 
@@ -75,6 +76,8 @@ afterAll((done) => { server.close(done); });
 beforeEach(() => {
   jest.clearAllMocks();
   authMock.__setConfigured(true);
+  // The adoption memo is per-instance, so it would otherwise carry between tests.
+  __resetAdoptionMemo();
 });
 
 async function call(path: string, init: any = {}) {
@@ -141,6 +144,7 @@ describe('GET /games', () => {
     mockQuery
       .mockResolvedValueOnce(rows([game()]))
       .mockResolvedValueOnce(rows([{ week: 1 }]))
+      .mockResolvedValueOnce(rows([{ n: 0 }]))   // adoption check
       .mockResolvedValueOnce(rows([{
         game_id: 'g1', pick_type: 'ats', selected: 'away',
         spread_at_pick: -2.5, updated_at: { value: '2026-09-01T00:00:00Z' },
@@ -354,5 +358,41 @@ describe('adopting imported picks', () => {
       .mockResolvedValueOnce(rows([]));
     await call('/api/pickem/me?season=2026', signedIn);
     expect(sentQueries().some((q) => /UPDATE .*picks/s.test(q))).toBe(false);
+  });
+});
+
+describe('adoption on the pick sheet', () => {
+  it('claims an imported history on the sheet, not only on /me', async () => {
+    // The bug this covers: signing in and going straight to the sheet showed no picks
+    // until some other request happened to trigger the transfer.
+    mockQuery
+      .mockResolvedValueOnce(rows([game()]))       // games
+      .mockResolvedValueOnce(rows([{ week: 1 }]))  // weeks
+      .mockResolvedValueOnce(rows([{ n: 42 }]))    // 42 waiting
+      .mockResolvedValueOnce(rows([]))             // UPDATE
+      .mockResolvedValueOnce(rows([]))             // DELETE picks
+      .mockResolvedValueOnce(rows([]))             // DELETE provisional user
+      .mockResolvedValueOnce(rows([]));            // the user's picks
+
+    const { status } = await call('/api/pickem/games?sport=nfl&week=1', signedIn);
+    expect(status).toBe(200);
+    expect(sentQueries().some((q) => /UPDATE .*picks/s.test(q))).toBe(true);
+  });
+
+  it('checks once per user rather than on every sheet request', async () => {
+    // The sheet is the most-requested endpoint; a query per request would be waste.
+    for (let i = 0; i < 3; i += 1) {
+      mockQuery
+        .mockResolvedValueOnce(rows([game()]))
+        .mockResolvedValueOnce(rows([{ week: 1 }]))
+        .mockResolvedValueOnce(rows([{ n: 0 }]))
+        .mockResolvedValueOnce(rows([]));
+    }
+    await call('/api/pickem/games?sport=nfl&week=1', signedIn);
+    await call('/api/pickem/games?sport=nfl&week=1', signedIn);
+    await call('/api/pickem/games?sport=nfl&week=1', signedIn);
+
+    const checks = sentQueries().filter((q) => /COUNT\(\*\) AS n[\s\S]*user_id = @provisional/.test(q));
+    expect(checks).toHaveLength(1);
   });
 });

--- a/src/app.ts
+++ b/src/app.ts
@@ -14,6 +14,7 @@ import scoutingReportsRoutes from './routes/scouting-reports.routes';
 import nflRoutes from './routes/nfl.routes';
 import footballRoutes from './routes/football.routes';
 import rankingsRoutes from './routes/rankings.routes';
+import pickemRoutes from './routes/pickem.routes';
 import { validateGCPConfig } from './config/gcp.config';
 import { schedulerService } from './services/scheduler.service';
 
@@ -69,6 +70,7 @@ app.use('/api/predictions', predictionsRoutes); // Game predictions and matchup 
 app.use('/api/scouting-reports', scoutingReportsRoutes); // Pre-computed daily scouting reports
 app.use('/api/football', footballRoutes); // NFL + CFB predictions, accuracy, searchable stats
 app.use('/api/rankings', rankingsRoutes); // Bradley-Terry power rankings, all sports
+app.use('/api/pickem', pickemRoutes); // Pick'em contest: sheet, picks, leaderboard
 app.use('/api/nfl', nflRoutes); // legacy alias for /api/football/nfl
 app.use('/api', legacyRoutes); // Legacy endpoints for backward compatibility
 

--- a/src/config/football-columns.config.ts
+++ b/src/config/football-columns.config.ts
@@ -242,6 +242,123 @@ const NFL_WEEK_EPA: ColumnSpec[] = [
   { key: 'def_plays', label: 'Def Plays', group: 'defense', format: 'integer' },
 ];
 
+
+/* ------------------------------------------------------------------------- *
+ * CFB per-team, per-game advanced stats — cfb_season.team_game_advanced
+ *
+ * The college answer to nfl_historical.team_week_epa, and a richer one: PPA in place
+ * of EPA, plus line yards, stuff rate, power success, havoc and the standard/passing
+ * downs splits, none of which the NFL table carries.
+ *
+ * The first six keys are aliased in SQL to the NFL table's canonical names, so one
+ * client renderer serves both sports without learning two vocabularies.
+ * ------------------------------------------------------------------------- */
+
+const CFB_GAME_ADVANCED: ColumnSpec[] = [
+  { key: 'season', label: 'Season', group: 'core', format: 'integer' },
+  { key: 'week', label: 'Wk', group: 'core', format: 'integer' },
+  { key: 'team', label: 'Team', group: 'core', format: 'text' },
+  { key: 'opponent', label: 'Opp', group: 'core', format: 'text' },
+  // Aliased from ppa / success_rate / explosiveness — see statsFieldMap.
+  { key: 'off_epa_play', label: 'Off PPA', group: 'offense', format: 'decimal3', higherIsBetter: true },
+  { key: 'off_success_rate', label: 'Off SR', group: 'offense', format: 'rate', higherIsBetter: true },
+  { key: 'off_explosive_rate', label: 'Off Explosive', group: 'offense', format: 'decimal2', higherIsBetter: true },
+  { key: 'off_plays', label: 'Plays', group: 'offense', format: 'integer' },
+  { key: 'off_drives', label: 'Drives', group: 'offense', format: 'integer' },
+  { key: 'off_line_yards', label: 'Line Yds', group: 'line', format: 'decimal2', higherIsBetter: true },
+  { key: 'off_second_level_yards', label: '2nd Level', group: 'line', format: 'decimal2', higherIsBetter: true },
+  { key: 'off_open_field_yards', label: 'Open Field', group: 'line', format: 'decimal2', higherIsBetter: true },
+  { key: 'off_stuff_rate', label: 'Stuffed', group: 'line', format: 'rate', higherIsBetter: false },
+  { key: 'off_power_success', label: 'Power Succ', group: 'line', format: 'rate', higherIsBetter: true },
+  { key: 'off_standard_downs_ppa', label: 'Std Downs PPA', group: 'situational', format: 'decimal3', higherIsBetter: true },
+  { key: 'off_passing_downs_ppa', label: 'Pass Downs PPA', group: 'situational', format: 'decimal3', higherIsBetter: true },
+  { key: 'off_rushing_plays_ppa', label: 'Rush PPA', group: 'situational', format: 'decimal3', higherIsBetter: true },
+  { key: 'off_passing_plays_ppa', label: 'Pass PPA', group: 'situational', format: 'decimal3', higherIsBetter: true },
+  // Defensive: what opponents managed, so lower is better throughout.
+  { key: 'def_epa_play', label: 'Def PPA', group: 'defense', format: 'decimal3', higherIsBetter: false, opponent: true },
+  { key: 'def_success_rate', label: 'Def SR', group: 'defense', format: 'rate', higherIsBetter: false, opponent: true },
+  { key: 'def_explosive_rate', label: 'Def Explosive', group: 'defense', format: 'decimal2', higherIsBetter: false, opponent: true },
+  { key: 'def_line_yards', label: 'Line Yds Allowed', group: 'defense', format: 'decimal2', higherIsBetter: false, opponent: true },
+  { key: 'def_stuff_rate', label: 'Stuffs Made', group: 'defense', format: 'rate', higherIsBetter: true, opponent: true },
+  // Havoc rate is published only by the SEASON advanced endpoint, not the per-game
+  // one, so it belongs to team_season_advanced and is absent here.
+  { key: 'def_plays', label: 'Def Plays', group: 'defense', format: 'integer', opponent: true },
+];
+
+/* CFB player season stats — cfb_season.player_season_stats.
+ * Pivoted from CollegeFootballData, which finally makes a college player table
+ * possible: ESPN's sortable athlete endpoint returns "-" for the stat it sorts on. */
+
+const CFB_PLAYER_SEASON: ColumnSpec[] = [
+  { key: 'player_name', label: 'Player', group: 'core', format: 'text' },
+  { key: 'position', label: 'Pos', group: 'core', format: 'text' },
+  { key: 'team', label: 'Team', group: 'core', format: 'text' },
+  { key: 'conference', label: 'Conf', group: 'core', format: 'text' },
+  { key: 'passing_yds', label: 'Pass Yds', group: 'passing', format: 'integer', higherIsBetter: true },
+  { key: 'passing_td', label: 'Pass TD', group: 'passing', format: 'integer', higherIsBetter: true },
+  { key: 'passing_int', label: 'INT', group: 'passing', format: 'integer', higherIsBetter: false },
+  { key: 'passing_att', label: 'Att', group: 'passing', format: 'integer' },
+  { key: 'passing_completions', label: 'Cmp', group: 'passing', format: 'integer' },
+  { key: 'passing_pct', label: 'Cmp%', group: 'passing', format: 'rate', higherIsBetter: true },
+  { key: 'passing_ypa', label: 'Y/A', group: 'passing', format: 'decimal2', higherIsBetter: true },
+  { key: 'rushing_yds', label: 'Rush Yds', group: 'rushing', format: 'integer', higherIsBetter: true },
+  { key: 'rushing_td', label: 'Rush TD', group: 'rushing', format: 'integer', higherIsBetter: true },
+  { key: 'rushing_car', label: 'Car', group: 'rushing', format: 'integer' },
+  { key: 'rushing_ypc', label: 'Y/C', group: 'rushing', format: 'decimal2', higherIsBetter: true },
+  { key: 'rushing_long', label: 'Long', group: 'rushing', format: 'integer' },
+  { key: 'receiving_yds', label: 'Rec Yds', group: 'receiving', format: 'integer', higherIsBetter: true },
+  { key: 'receiving_rec', label: 'Rec', group: 'receiving', format: 'integer', higherIsBetter: true },
+  { key: 'receiving_td', label: 'Rec TD', group: 'receiving', format: 'integer', higherIsBetter: true },
+  { key: 'receiving_ypr', label: 'Y/R', group: 'receiving', format: 'decimal2', higherIsBetter: true },
+  { key: 'defensive_tot', label: 'Tackles', group: 'defense', format: 'decimal1', higherIsBetter: true },
+  { key: 'defensive_solo', label: 'Solo', group: 'defense', format: 'decimal1', higherIsBetter: true },
+  { key: 'defensive_sacks', label: 'Sacks', group: 'defense', format: 'decimal1', higherIsBetter: true },
+  { key: 'defensive_tfl', label: 'TFL', group: 'defense', format: 'decimal1', higherIsBetter: true },
+  { key: 'defensive_qb_hur', label: 'QB Hur', group: 'defense', format: 'integer', higherIsBetter: true },
+  { key: 'interceptions_int', label: 'INT', group: 'defense', format: 'integer', higherIsBetter: true },
+  { key: 'kicking_fgm', label: 'FG', group: 'kicking', format: 'integer', higherIsBetter: true },
+  { key: 'kicking_fga', label: 'FGA', group: 'kicking', format: 'integer' },
+  { key: 'kicking_pct', label: 'FG%', group: 'kicking', format: 'rate', higherIsBetter: true },
+  { key: 'kicking_pts', label: 'Pts', group: 'kicking', format: 'integer', higherIsBetter: true },
+];
+
+/* NFL player season stats — nfl_season.player_season_stats (148 columns; this is the
+ * readable subset). Keys are the CANONICAL names shared with the college catalog, so
+ * both sports answer in one vocabulary and the client renders either without branching.
+ * The physical nflverse names are supplied by the sport's playerFieldMap. */
+
+const NFL_PLAYER_SEASON: ColumnSpec[] = [
+  { key: 'player_name', label: 'Player', group: 'core', format: 'text' },
+  { key: 'position', label: 'Pos', group: 'core', format: 'text' },
+  { key: 'team', label: 'Team', group: 'core', format: 'text' },
+  { key: 'games', label: 'G', group: 'core', format: 'integer' },
+  { key: 'passing_yds', label: 'Pass Yds', group: 'passing', format: 'integer', higherIsBetter: true },
+  { key: 'passing_td', label: 'Pass TD', group: 'passing', format: 'integer', higherIsBetter: true },
+  { key: 'passing_int', label: 'INT', group: 'passing', format: 'integer', higherIsBetter: false },
+  { key: 'passing_att', label: 'Att', group: 'passing', format: 'integer' },
+  { key: 'passing_completions', label: 'Cmp', group: 'passing', format: 'integer' },
+  // EPA and CPOE have no college analogue; the catalog carries what each sport has.
+  { key: 'passing_epa', label: 'Pass EPA', group: 'passing', format: 'decimal2', higherIsBetter: true },
+  { key: 'passing_cpoe', label: 'CPOE', group: 'passing', format: 'decimal2', higherIsBetter: true },
+  { key: 'rushing_yds', label: 'Rush Yds', group: 'rushing', format: 'integer', higherIsBetter: true },
+  { key: 'rushing_td', label: 'Rush TD', group: 'rushing', format: 'integer', higherIsBetter: true },
+  { key: 'rushing_car', label: 'Car', group: 'rushing', format: 'integer' },
+  { key: 'rushing_epa', label: 'Rush EPA', group: 'rushing', format: 'decimal2', higherIsBetter: true },
+  { key: 'receiving_yds', label: 'Rec Yds', group: 'receiving', format: 'integer', higherIsBetter: true },
+  { key: 'receiving_rec', label: 'Rec', group: 'receiving', format: 'integer', higherIsBetter: true },
+  { key: 'receiving_td', label: 'Rec TD', group: 'receiving', format: 'integer', higherIsBetter: true },
+  { key: 'targets', label: 'Tgt', group: 'receiving', format: 'integer' },
+  { key: 'receiving_epa', label: 'Rec EPA', group: 'receiving', format: 'decimal2', higherIsBetter: true },
+  { key: 'target_share', label: 'Tgt Share', group: 'receiving', format: 'rate', higherIsBetter: true },
+  { key: 'defensive_sacks', label: 'Sacks', group: 'defense', format: 'decimal1', higherIsBetter: true },
+  { key: 'defensive_solo', label: 'Solo', group: 'defense', format: 'integer', higherIsBetter: true },
+  { key: 'interceptions_int', label: 'INT', group: 'defense', format: 'integer', higherIsBetter: true },
+  { key: 'defensive_pd', label: 'PD', group: 'defense', format: 'integer', higherIsBetter: true },
+  { key: 'kicking_fgm', label: 'FG', group: 'kicking', format: 'integer', higherIsBetter: true },
+  { key: 'kicking_fga', label: 'FGA', group: 'kicking', format: 'integer' },
+  { key: 'headshot_url', label: 'Headshot', group: 'core', format: 'text' },
+];
+
 /* ------------------------------------------------------------------------- */
 
 export const COLUMN_CATALOGS: Record<string, ColumnCatalog> = {
@@ -250,6 +367,41 @@ export const COLUMN_CATALOGS: Record<string, ColumnCatalog> = {
     identity: ['season', 'week', 'team'],
     groups: [g('core', 'Overview'), g('offense', 'Offense'), g('defense', 'Defense')],
     columns: NFL_WEEK_EPA,
+  },
+  cfb_team_game: {
+    identity: ['season', 'week', 'team', 'opponent'],
+    groups: [
+      g('core', 'Overview'),
+      g('offense', 'Offense'),
+      g('line', 'Line & Rushing'),
+      g('situational', 'By Down & Play Type'),
+      g('defense', 'Defense'),
+    ],
+    columns: CFB_GAME_ADVANCED,
+  },
+  nfl_player_season: {
+    identity: ['player_name', 'position', 'team'],
+    groups: [
+      g('core', 'Player'),
+      g('passing', 'Passing'),
+      g('rushing', 'Rushing'),
+      g('receiving', 'Receiving'),
+      g('defense', 'Defense'),
+      g('kicking', 'Kicking'),
+    ],
+    columns: NFL_PLAYER_SEASON,
+  },
+  cfb_player_season: {
+    identity: ['player_name', 'position', 'team'],
+    groups: [
+      g('core', 'Player'),
+      g('passing', 'Passing'),
+      g('rushing', 'Rushing'),
+      g('receiving', 'Receiving'),
+      g('defense', 'Defense'),
+      g('kicking', 'Kicking'),
+    ],
+    columns: CFB_PLAYER_SEASON,
   },
 };
 

--- a/src/config/football-columns.config.ts
+++ b/src/config/football-columns.config.ts
@@ -1,0 +1,313 @@
+/**
+ * Column catalogs for the football stats endpoints.
+ *
+ * Separate from football.config.ts on purpose. That file answers "which tables does this
+ * sport have", in about ninety lines. This one is presentation metadata — hundreds of
+ * entries of label, grouping and formatting — and merging the two would bury the registry
+ * in it.
+ *
+ * The catalog is what lets one endpoint serve two sports whose column sets have almost
+ * nothing in common. Rather than reconciling ESPN's 154 college columns with nflverse's
+ * 136 NFL ones, each response carries `meta.columns` describing exactly the columns in
+ * `data`, and the client renders headers, number formats and good/bad colouring from
+ * that. RankingsBoard already works this way: it drops optional columns no row has a
+ * value for.
+ *
+ * It doubles as the projection allow-list. `SELECT *` on a 154-column table is multi-MB
+ * of JSON per request, so a caller gets `group=core` by default and has to name the
+ * groups or fields it wants beyond that.
+ */
+
+/** How the client should render a value. Not a width or a unit — just a number shape. */
+export type ColumnFormat =
+  | 'text'
+  | 'integer'
+  | 'decimal1'
+  | 'decimal2'
+  | 'decimal3'
+  | 'percent'   // already 0-100 in the source
+  | 'rate';     // 0-1, render as a percentage
+
+export interface ColumnSpec {
+  key: string;
+  label: string;
+  group: string;
+  format: ColumnFormat;
+  /** Absent where "better" is not meaningful — identity columns, volume counts. */
+  higherIsBetter?: boolean;
+  /** True for a column describing what opponents did, so the UI can flip its colouring. */
+  opponent?: boolean;
+}
+
+export interface ColumnGroup {
+  key: string;
+  label: string;
+}
+
+export interface ColumnCatalog {
+  /** Always projected, whatever groups are requested — the row's identity. */
+  identity: string[];
+  groups: ColumnGroup[];
+  columns: ColumnSpec[];
+}
+
+const g = (key: string, label: string): ColumnGroup => ({ key, label });
+
+/* ------------------------------------------------------------------------- *
+ * CFB team season stats — ESPN, 154 columns, camelCase, `opp_` opponent split
+ * ------------------------------------------------------------------------- */
+
+/**
+ * ESPN publishes each stat twice: the team's own production and what its opponents did
+ * against it (split 900). The opponent half is the only defensive information the feed
+ * carries, which is why it is kept rather than dropped — but it means "higher is better"
+ * inverts for every `opp_` column, so `opponent: true` marks them for the client.
+ */
+const CFB_OWN: Array<[string, string, string, ColumnFormat, boolean?]> = [
+  // core
+  ['gamesPlayed', 'G', 'core', 'integer'],
+  ['totalPointsPerGame', 'PPG', 'core', 'decimal1', true],
+  ['totalPoints', 'Pts', 'core', 'integer', true],
+  ['yardsPerGame', 'Yds/G', 'core', 'decimal1', true],
+  ['totalYards', 'Total Yds', 'core', 'integer', true],
+  ['firstDowns', '1st Downs', 'core', 'integer', true],
+  // passing
+  ['passingYards', 'Pass Yds', 'passing', 'integer', true],
+  ['passingYardsPerGame', 'Pass Yds/G', 'passing', 'decimal1', true],
+  ['passingTouchdowns', 'Pass TD', 'passing', 'integer', true],
+  ['completions', 'Cmp', 'passing', 'integer'],
+  ['passingAttempts', 'Att', 'passing', 'integer'],
+  ['completionPct', 'Cmp%', 'passing', 'percent', true],
+  ['yardsPerPassAttempt', 'Y/A', 'passing', 'decimal2', true],
+  ['QBRating', 'QB Rtg', 'passing', 'decimal1', true],
+  ['interceptions', 'INT', 'passing', 'integer', false],
+  ['sacks', 'Sacks Allowed', 'passing', 'integer', false],
+  ['sackYardsLost', 'Sack Yds', 'passing', 'integer', false],
+  ['longPassing', 'Long Pass', 'passing', 'integer'],
+  ['firstDownsPassing', '1st Pass', 'passing', 'integer', true],
+  // rushing
+  ['rushingYards', 'Rush Yds', 'rushing', 'integer', true],
+  ['rushingYardsPerGame', 'Rush Yds/G', 'rushing', 'decimal1', true],
+  ['rushingTouchdowns', 'Rush TD', 'rushing', 'integer', true],
+  ['rushingAttempts', 'Carries', 'rushing', 'integer'],
+  ['yardsPerRushAttempt', 'Y/C', 'rushing', 'decimal2', true],
+  ['longRushing', 'Long Rush', 'rushing', 'integer'],
+  ['rushingFumbles', 'Rush Fum', 'rushing', 'integer', false],
+  ['firstDownsRushing', '1st Rush', 'rushing', 'integer', true],
+  // receiving
+  ['receptions', 'Rec', 'receiving', 'integer'],
+  ['receivingYards', 'Rec Yds', 'receiving', 'integer', true],
+  ['receivingYardsPerGame', 'Rec Yds/G', 'receiving', 'decimal1', true],
+  ['receivingTouchdowns', 'Rec TD', 'receiving', 'integer', true],
+  ['yardsPerReception', 'Y/R', 'receiving', 'decimal2', true],
+  ['longReception', 'Long Rec', 'receiving', 'integer'],
+  // efficiency
+  ['thirdDownConvPct', '3rd Down %', 'efficiency', 'percent', true],
+  ['thirdDownConvs', '3rd Conv', 'efficiency', 'integer', true],
+  ['thirdDownAttempts', '3rd Att', 'efficiency', 'integer'],
+  ['fourthDownConvPct', '4th Down %', 'efficiency', 'percent', true],
+  ['fourthDownConvs', '4th Conv', 'efficiency', 'integer', true],
+  ['fourthDownAttempts', '4th Att', 'efficiency', 'integer'],
+  ['fumblesRecovered', 'Fum Rec', 'efficiency', 'integer', true],
+  ['totalPenalties', 'Penalties', 'efficiency', 'integer', false],
+  ['totalPenaltyYards', 'Pen Yds', 'efficiency', 'integer', false],
+  ['firstDownsPenalty', '1st by Pen', 'efficiency', 'integer'],
+  // kicking
+  ['fieldGoalsMade', 'FG', 'kicking', 'integer', true],
+  ['fieldGoalAttempts', 'FGA', 'kicking', 'integer'],
+  ['fieldGoalPct', 'FG%', 'kicking', 'percent', true],
+  ['longFieldGoalMade', 'Long FG', 'kicking', 'integer', true],
+  ['extraPointsMade', 'XP', 'kicking', 'integer', true],
+  ['extraPointAttempts', 'XPA', 'kicking', 'integer'],
+  ['extraPointPct', 'XP%', 'kicking', 'percent', true],
+  ['fieldGoalsMade1_19', 'FG 1-19', 'kicking', 'integer', true],
+  ['fieldGoalsMade20_29', 'FG 20-29', 'kicking', 'integer', true],
+  ['fieldGoalsMade30_39', 'FG 30-39', 'kicking', 'integer', true],
+  ['fieldGoalsMade40_49', 'FG 40-49', 'kicking', 'integer', true],
+  ['fieldGoalsMade50', 'FG 50+', 'kicking', 'integer', true],
+  ['fieldGoalAttempts1_19', 'FGA 1-19', 'kicking', 'integer'],
+  ['fieldGoalAttempts20_29', 'FGA 20-29', 'kicking', 'integer'],
+  ['fieldGoalAttempts30_39', 'FGA 30-39', 'kicking', 'integer'],
+  ['fieldGoalAttempts40_49', 'FGA 40-49', 'kicking', 'integer'],
+  ['fieldGoalAttempts50', 'FGA 50+', 'kicking', 'integer'],
+  // returns
+  ['kickReturns', 'KR', 'returns', 'integer'],
+  ['kickReturnYards', 'KR Yds', 'returns', 'integer', true],
+  ['yardsPerKickReturn', 'KR Avg', 'returns', 'decimal2', true],
+  ['longKickReturn', 'Long KR', 'returns', 'integer'],
+  ['kickReturnTouchdowns', 'KR TD', 'returns', 'integer', true],
+  ['puntReturns', 'PR', 'returns', 'integer'],
+  ['puntReturnYards', 'PR Yds', 'returns', 'integer', true],
+  ['yardsPerPuntReturn', 'PR Avg', 'returns', 'decimal2', true],
+  ['longPuntReturn', 'Long PR', 'returns', 'integer'],
+  ['puntReturnTouchdowns', 'PR TD', 'returns', 'integer', true],
+  // punting
+  ['punts', 'Punts', 'punting', 'integer'],
+  ['puntYards', 'Punt Yds', 'punting', 'integer'],
+  ['grossAvgPuntYards', 'Gross Avg', 'punting', 'decimal2', true],
+  ['netAvgPuntYards', 'Net Avg', 'punting', 'decimal2', true],
+  ['longPunt', 'Long Punt', 'punting', 'integer'],
+];
+
+/** Opponent-split labels that read as defense rather than as "their offense". */
+const CFB_OPP_LABELS: Record<string, string> = {
+  opp_totalPointsPerGame: 'PPG Allowed',
+  opp_totalPoints: 'Pts Allowed',
+  opp_yardsPerGame: 'Yds/G Allowed',
+  opp_totalYards: 'Total Yds Allowed',
+  opp_passingYards: 'Pass Yds Allowed',
+  opp_passingYardsPerGame: 'Pass Yds/G Allowed',
+  opp_rushingYards: 'Rush Yds Allowed',
+  opp_rushingYardsPerGame: 'Rush Yds/G Allowed',
+  opp_firstDowns: '1st Downs Allowed',
+  opp_thirdDownConvPct: '3rd Down % Allowed',
+  opp_interceptions: 'INT Forced',
+  opp_sacks: 'Sacks Made',
+  opp_completionPct: 'Cmp% Allowed',
+  opp_QBRating: 'QB Rtg Allowed',
+  opp_gamesPlayed: 'Opp G',
+  opp_fumblesRecovered: 'Fum Lost',
+  opp_totalPenalties: 'Opp Penalties',
+  opp_totalPenaltyYards: 'Opp Pen Yds',
+};
+
+function cfbSeasonCatalog(): ColumnCatalog {
+  // espn_team_id is the table's 154th column and is deliberately absent: it is an
+  // internal join key, not a stat, and nothing should be sorting or displaying it.
+  const columns: ColumnSpec[] = [
+    { key: 'season', label: 'Season', group: 'core', format: 'integer' },
+    { key: 'team', label: 'Team', group: 'core', format: 'text' },
+    { key: 'team_abbr', label: 'Abbr', group: 'core', format: 'text' },
+  ];
+
+  for (const [key, label, group, format, higherIsBetter] of CFB_OWN) {
+    columns.push({ key, label, group, format, higherIsBetter });
+  }
+
+  // The opponent split mirrors the own-production columns exactly, so it is derived
+  // rather than retyped — 75 hand-copied rows is 75 chances to typo a key.
+  for (const [key, label, group, format, higherIsBetter] of CFB_OWN) {
+    const oppKey = `opp_${key}`;
+    columns.push({
+      key: oppKey,
+      label: CFB_OPP_LABELS[oppKey] || `${label} Allowed`,
+      group: 'defense',
+      format,
+      // What the opponent did: if more of it is good for them, it is bad for us.
+      higherIsBetter:
+        higherIsBetter === undefined ? undefined : !higherIsBetter,
+      opponent: true,
+    });
+  }
+
+  return {
+    identity: ['season', 'team', 'team_abbr'],
+    groups: [
+      g('core', 'Overview'),
+      g('passing', 'Passing'),
+      g('rushing', 'Rushing'),
+      g('receiving', 'Receiving'),
+      g('efficiency', 'Efficiency & Penalties'),
+      g('kicking', 'Kicking'),
+      g('returns', 'Returns'),
+      g('punting', 'Punting'),
+      g('defense', 'Opponent (Defense)'),
+    ],
+    columns,
+  };
+}
+
+/* ------------------------------------------------------------------------- *
+ * NFL per-team, per-week EPA — nfl_historical.team_week_epa, 17 columns
+ * ------------------------------------------------------------------------- */
+
+const NFL_WEEK_EPA: ColumnSpec[] = [
+  { key: 'season', label: 'Season', group: 'core', format: 'integer' },
+  { key: 'week', label: 'Wk', group: 'core', format: 'integer' },
+  { key: 'team', label: 'Team', group: 'core', format: 'text' },
+  { key: 'off_epa_play', label: 'Off EPA', group: 'offense', format: 'decimal3', higherIsBetter: true },
+  { key: 'off_pass_epa', label: 'Off Pass EPA', group: 'offense', format: 'decimal3', higherIsBetter: true },
+  { key: 'off_rush_epa', label: 'Off Rush EPA', group: 'offense', format: 'decimal3', higherIsBetter: true },
+  { key: 'off_success_rate', label: 'Off SR', group: 'offense', format: 'rate', higherIsBetter: true },
+  { key: 'off_explosive_rate', label: 'Off Explosive', group: 'offense', format: 'rate', higherIsBetter: true },
+  { key: 'off_turnovers', label: 'Turnovers', group: 'offense', format: 'integer', higherIsBetter: false },
+  { key: 'off_plays', label: 'Off Plays', group: 'offense', format: 'integer' },
+  // Defensive EPA is negative-is-better: it is the EPA the defense allowed.
+  { key: 'def_epa_play', label: 'Def EPA', group: 'defense', format: 'decimal3', higherIsBetter: false },
+  { key: 'def_pass_epa', label: 'Def Pass EPA', group: 'defense', format: 'decimal3', higherIsBetter: false },
+  { key: 'def_rush_epa', label: 'Def Rush EPA', group: 'defense', format: 'decimal3', higherIsBetter: false },
+  { key: 'def_success_rate', label: 'Def SR', group: 'defense', format: 'rate', higherIsBetter: false },
+  { key: 'def_explosive_rate', label: 'Def Explosive', group: 'defense', format: 'rate', higherIsBetter: false },
+  { key: 'def_takeaways', label: 'Takeaways', group: 'defense', format: 'integer', higherIsBetter: true },
+  { key: 'def_plays', label: 'Def Plays', group: 'defense', format: 'integer' },
+];
+
+/* ------------------------------------------------------------------------- */
+
+export const COLUMN_CATALOGS: Record<string, ColumnCatalog> = {
+  cfb_team_season: cfbSeasonCatalog(),
+  nfl_team_week: {
+    identity: ['season', 'week', 'team'],
+    groups: [g('core', 'Overview'), g('offense', 'Offense'), g('defense', 'Defense')],
+    columns: NFL_WEEK_EPA,
+  },
+};
+
+export function getColumnCatalog(name: string | null): ColumnCatalog | null {
+  if (!name) return null;
+  return COLUMN_CATALOGS[name] || null;
+}
+
+/**
+ * Resolve a `group`/`fields` request into the columns to project.
+ *
+ * Identity columns are always included, so a row is never returned without enough of it
+ * to identify what it describes. Unknown group and field names are reported back rather
+ * than ignored — silently returning the default set for a typo'd `fields` is how a
+ * caller ends up believing a column does not exist.
+ */
+export function resolveColumns(
+  catalog: ColumnCatalog,
+  opts: { fields?: string; group?: string },
+): { columns: ColumnSpec[]; unknown: string[] } {
+  const byKey = new Map(catalog.columns.map((c) => [c.key, c]));
+  const unknown: string[] = [];
+
+  const requestedFields = (opts.fields || '')
+    .split(',').map((s) => s.trim()).filter(Boolean);
+
+  if (requestedFields.length) {
+    const picked = new Map<string, ColumnSpec>();
+    for (const key of catalog.identity) {
+      const spec = byKey.get(key);
+      if (spec) picked.set(key, spec);
+    }
+    for (const key of requestedFields) {
+      const spec = byKey.get(key);
+      if (!spec) { unknown.push(key); continue; }
+      picked.set(key, spec);
+    }
+    return { columns: [...picked.values()], unknown };
+  }
+
+  const validGroups = new Set(catalog.groups.map((gr) => gr.key));
+  let requestedGroups = (opts.group || 'core')
+    .split(',').map((s) => s.trim()).filter(Boolean);
+
+  for (const key of requestedGroups) {
+    if (key !== 'all' && !validGroups.has(key)) unknown.push(key);
+  }
+  requestedGroups = requestedGroups.filter(
+    (key) => key === 'all' || validGroups.has(key),
+  );
+  if (!requestedGroups.length) requestedGroups = ['core'];
+
+  const wanted = new Set(requestedGroups);
+  const columns = wanted.has('all')
+    ? catalog.columns
+    : catalog.columns.filter(
+        (c) => wanted.has(c.group) || catalog.identity.includes(c.key),
+      );
+
+  return { columns, unknown };
+}

--- a/src/config/football.config.ts
+++ b/src/config/football.config.ts
@@ -19,6 +19,16 @@
  */
 export type DatasetKind = 'season' | 'hist';
 
+/**
+ * Canonical stat key -> the column that holds it in this sport's table.
+ *
+ * The two sports measure the same ideas with different names — the NFL table stores
+ * per-play EPA, the college one stores PPA — so the alias happens once in SQL and the
+ * client only ever sees the canonical name. Teaching the frontend two vocabularies was
+ * the alternative, and it is how the college stats page stayed empty for months.
+ */
+export type StatsFieldMap = Record<string, string>;
+
 export interface FootballSportConfig {
   key: string;
   label: string;
@@ -31,6 +41,14 @@ export interface FootballSportConfig {
   statsDataset: DatasetKind;
   /** Catalog key in football-columns.config for the per-week table. */
   statsColumnCatalog: string | null;
+  /** Canonical -> physical column names for the per-week table. */
+  statsFieldMap?: StatsFieldMap;
+  /** Catalog key for the per-player table. */
+  playerColumnCatalog: string | null;
+  /** Canonical -> physical column names for the per-player table. */
+  playerFieldMap?: StatsFieldMap;
+  /** Sortable player columns, allow-listed for the ORDER BY. */
+  playerSortFields: string[];
   /** Per-team SEASON totals, including opponent splits (college only for now). */
   teamSeasonTable: string | null;
   teamSeasonDataset: DatasetKind;
@@ -94,6 +112,38 @@ export const FOOTBALL_SPORTS: Record<string, FootballSportConfig> = {
     statsTable: 'team_week_epa',
     statsDataset: 'hist',
     statsColumnCatalog: 'nfl_team_week',
+    // Identity: the NFL table already uses the canonical names.
+    statsFieldMap: Object.fromEntries(NFL_STAT_FIELDS.map((f) => [f, f])),
+    playerColumnCatalog: 'nfl_player_season',
+    // nflverse's own names, mapped onto the canonical keys the catalog declares.
+    playerFieldMap: {
+      player_name: 'player_display_name',
+      team: 'recent_team',
+      passing_yds: 'passing_yards',
+      passing_td: 'passing_tds',
+      passing_int: 'passing_interceptions',
+      passing_att: 'attempts',
+      passing_completions: 'completions',
+      rushing_yds: 'rushing_yards',
+      rushing_td: 'rushing_tds',
+      rushing_car: 'carries',
+      receiving_yds: 'receiving_yards',
+      receiving_rec: 'receptions',
+      receiving_td: 'receiving_tds',
+      defensive_sacks: 'def_sacks',
+      defensive_solo: 'def_tackles_solo',
+      interceptions_int: 'def_interceptions',
+      defensive_pd: 'def_pass_defended',
+      kicking_fgm: 'fg_made',
+      kicking_fga: 'fg_att',
+    },
+    playerSortFields: [
+      'passing_yds', 'passing_td', 'passing_epa', 'passing_int',
+      'passing_completions', 'passing_att', 'rushing_yds', 'rushing_td',
+      'rushing_car', 'rushing_epa', 'receiving_yds', 'receiving_td',
+      'receiving_rec', 'targets', 'receiving_epa', 'defensive_sacks',
+      'defensive_solo', 'interceptions_int', 'defensive_pd', 'games',
+    ],
     hasDivisions: false,
     sortableStatFields: NFL_STAT_FIELDS,
     // nflverse publishes a 136-column team-season table; not ingested yet.
@@ -112,13 +162,51 @@ export const FOOTBALL_SPORTS: Record<string, FootballSportConfig> = {
     histDataset: process.env.CFB_HIST_DATASET || 'cfb_historical',
     predictionsTable: 'game_predictions',
     gamesTable: 'games',
-    // No per-week feed yet: the college pipeline carries no play-by-play, so there is
-    // no EPA equivalent of nfl_historical.team_week_epa.
-    statsTable: null,
-    statsDataset: 'hist',
-    statsColumnCatalog: null,
+    // Per-team, per-game advanced stats from CollegeFootballData. The college answer
+    // to team_week_epa, and a richer one — PPA plus line yards, stuff rate, havoc and
+    // the down splits. Aliased below onto the NFL table's canonical names.
+    statsTable: 'team_game_advanced',
+    statsDataset: 'season',
+    statsColumnCatalog: 'cfb_team_game',
+    statsFieldMap: {
+      season: 'season', week: 'week', team: 'team', opponent: 'opponent',
+      off_epa_play: 'ppa',
+      off_success_rate: 'success_rate',
+      off_explosive_rate: 'explosiveness',
+      off_plays: 'plays',
+      off_drives: 'drives',
+      off_line_yards: 'line_yards',
+      off_second_level_yards: 'second_level_yards',
+      off_open_field_yards: 'open_field_yards',
+      off_stuff_rate: 'stuff_rate',
+      off_power_success: 'power_success',
+      off_standard_downs_ppa: 'standard_downs_ppa',
+      off_passing_downs_ppa: 'passing_downs_ppa',
+      off_rushing_plays_ppa: 'rushing_plays_ppa',
+      off_passing_plays_ppa: 'passing_plays_ppa',
+      def_epa_play: 'opp_ppa',
+      def_success_rate: 'opp_success_rate',
+      def_explosive_rate: 'opp_explosiveness',
+      def_line_yards: 'opp_line_yards',
+      def_stuff_rate: 'opp_stuff_rate',
+      def_plays: 'opp_plays',
+    },
+    playerColumnCatalog: 'cfb_player_season',
+    playerFieldMap: { player_name: 'player_name', team: 'team' },
+    playerSortFields: [
+      'passing_yds', 'passing_td', 'passing_att', 'passing_ypa', 'passing_pct',
+      'rushing_yds', 'rushing_td', 'rushing_car', 'rushing_ypc',
+      'receiving_yds', 'receiving_rec', 'receiving_td', 'receiving_ypr',
+      'defensive_tot', 'defensive_solo', 'defensive_sacks', 'defensive_tfl',
+      'interceptions_int', 'kicking_fgm', 'kicking_pts',
+    ],
     hasDivisions: true,
-    sortableStatFields: [],
+    sortableStatFields: [
+      'season', 'week', 'team', 'off_epa_play', 'def_epa_play',
+      'off_success_rate', 'def_success_rate', 'off_explosive_rate',
+      'def_explosive_rate', 'off_line_yards', 'off_stuff_rate',
+      'off_power_success', 'off_plays', 'off_drives',
+    ],
     teamSeasonTable: 'team_season_stats',
     teamSeasonDataset: 'season',
     teamSeasonColumnCatalog: 'cfb_team_season',
@@ -127,13 +215,8 @@ export const FOOTBALL_SPORTS: Record<string, FootballSportConfig> = {
     // CFB has no team metadata table yet, so no logos or colours for college.
     teamsTable: null,
     teamsDataset: 'hist',
-    playerTable: null,
+    playerTable: 'player_season_stats',
     leadersTable: 'stat_leaders',
-    // No public ESPN endpoint returns a full college per-player season table: the
-    // sortable athlete endpoint returns "-" for the very stat it sorts on, and passing
-    // an explicit category 400s. Leaders are what the feed can actually support.
-    playerNote: 'College player stats are limited to league leaders — the public feed '
-      + 'does not publish a full per-player season table.',
     sortableSeasonFields: CFB_SEASON_SORT_FIELDS,
   },
 };

--- a/src/config/football.config.ts
+++ b/src/config/football.config.ts
@@ -5,7 +5,19 @@
  * off this table rather than two near-identical controllers. MLB deliberately stays
  * separate — its predictions table carries ~90 baseball-specific columns and lineup
  * joins that have no football analogue.
+ *
+ * A null table field means the sport structurally cannot answer that resource, and the
+ * handler says so with a note instead of an error. That is different from a table that
+ * is configured but not built yet, which surfaces as a caught missing-table. Keeping the
+ * two distinguishable is why the fields are nullable rather than absent.
  */
+
+/**
+ * Which dataset a table lives in. Not derivable per sport: NFL's per-week stats are in
+ * the historical dataset while CFB's season totals are in the season dataset, so a
+ * handler cannot assume one dataset per resource kind.
+ */
+export type DatasetKind = 'season' | 'hist';
 
 export interface FootballSportConfig {
   key: string;
@@ -14,11 +26,25 @@ export interface FootballSportConfig {
   histDataset: string;
   predictionsTable: string;
   gamesTable: string;
-  /** Per-team, per-week advanced stats. NFL has EPA; CFB has none from the free feed. */
+  /** Per-team, per-week advanced stats. NFL has EPA; CFB gets a PPA equivalent later. */
   statsTable: string | null;
-  /** Per-team SEASON totals, including opponent splits (college only). */
+  statsDataset: DatasetKind;
+  /** Catalog key in football-columns.config for the per-week table. */
+  statsColumnCatalog: string | null;
+  /** Per-team SEASON totals, including opponent splits (college only for now). */
   teamSeasonTable: string | null;
-  /** Full per-player season table. NFL only — see playerNote for why. */
+  teamSeasonDataset: DatasetKind;
+  /** Catalog key in football-columns.config for the season table. */
+  teamSeasonColumnCatalog: string | null;
+  /**
+   * Stated where a sport's season table does not cover the whole league, so the UI can
+   * say which teams are missing rather than showing an unexplained short table.
+   */
+  teamSeasonCoverage?: string;
+  /** Team metadata: abbreviations, colours, logos. */
+  teamsTable: string | null;
+  teamsDataset: DatasetKind;
+  /** Full per-player season table. NFL only for now. */
   playerTable: string | null;
   /** League leaders, long-form: one row per (category, rank). */
   leadersTable: string | null;
@@ -28,11 +54,6 @@ export interface FootballSportConfig {
   /** CFB splits FBS/FCS via a division column; NFL has no such split. */
   hasDivisions: boolean;
   sortableStatFields: string[];
-  /**
-   * Bradley-Terry power rankings. Every sport now has a board; rankings themselves are
-   * served by rankings.controller, so this only records that the sport has one.
-   */
-  rankingsTable: string | null;
 }
 
 const NFL_STAT_FIELDS = [
@@ -40,6 +61,26 @@ const NFL_STAT_FIELDS = [
   'off_rush_epa', 'def_pass_epa', 'def_rush_epa', 'off_success_rate',
   'def_success_rate', 'off_explosive_rate', 'def_explosive_rate',
   'off_turnovers', 'def_takeaways', 'off_plays', 'def_plays',
+];
+
+/**
+ * Sortable season columns. BigQuery cannot parameterize an ORDER BY identifier, so the
+ * value from the query string is validated against this list and then interpolated.
+ * Kept deliberately shorter than the 153-column catalog: these are the cuts anyone
+ * actually sorts a league table by.
+ */
+const CFB_SEASON_SORT_FIELDS = [
+  'totalPointsPerGame', 'totalPoints', 'yardsPerGame', 'totalYards', 'gamesPlayed',
+  'passingYards', 'passingYardsPerGame', 'passingTouchdowns', 'completionPct',
+  'yardsPerPassAttempt', 'QBRating',
+  'rushingYards', 'rushingYardsPerGame', 'rushingTouchdowns', 'yardsPerRushAttempt',
+  'receivingYards', 'receivingTouchdowns',
+  'thirdDownConvPct', 'fourthDownConvPct', 'firstDowns',
+  'totalPenalties', 'totalPenaltyYards',
+  'fieldGoalPct', 'netAvgPuntYards',
+  'opp_totalPointsPerGame', 'opp_totalPoints', 'opp_yardsPerGame', 'opp_totalYards',
+  'opp_passingYards', 'opp_rushingYards', 'opp_thirdDownConvPct', 'opp_firstDowns',
+  'opp_sacks', 'opp_interceptions',
 ];
 
 export const FOOTBALL_SPORTS: Record<string, FootballSportConfig> = {
@@ -51,12 +92,18 @@ export const FOOTBALL_SPORTS: Record<string, FootballSportConfig> = {
     predictionsTable: 'game_predictions',
     gamesTable: 'games',
     statsTable: 'team_week_epa',
+    statsDataset: 'hist',
+    statsColumnCatalog: 'nfl_team_week',
     hasDivisions: false,
     sortableStatFields: NFL_STAT_FIELDS,
+    // nflverse publishes a 136-column team-season table; not ingested yet.
     teamSeasonTable: null,
+    teamSeasonDataset: 'season',
+    teamSeasonColumnCatalog: null,
+    teamsTable: 'teams',
+    teamsDataset: 'hist',
     playerTable: 'player_season_stats',
     leadersTable: 'stat_leaders',
-    rankingsTable: 'power_rankings',
   },
   cfb: {
     key: 'cfb',
@@ -65,10 +112,21 @@ export const FOOTBALL_SPORTS: Record<string, FootballSportConfig> = {
     histDataset: process.env.CFB_HIST_DATASET || 'cfb_historical',
     predictionsTable: 'game_predictions',
     gamesTable: 'games',
+    // No per-week feed yet: the college pipeline carries no play-by-play, so there is
+    // no EPA equivalent of nfl_historical.team_week_epa.
     statsTable: null,
+    statsDataset: 'hist',
+    statsColumnCatalog: null,
     hasDivisions: true,
     sortableStatFields: [],
     teamSeasonTable: 'team_season_stats',
+    teamSeasonDataset: 'season',
+    teamSeasonColumnCatalog: 'cfb_team_season',
+    teamSeasonCoverage: 'FBS only — the public feed does not publish an FCS season '
+      + 'table, so FCS teams have no row here.',
+    // CFB has no team metadata table yet, so no logos or colours for college.
+    teamsTable: null,
+    teamsDataset: 'hist',
     playerTable: null,
     leadersTable: 'stat_leaders',
     // No public ESPN endpoint returns a full college per-player season table: the
@@ -76,14 +134,15 @@ export const FOOTBALL_SPORTS: Record<string, FootballSportConfig> = {
     // an explicit category 400s. Leaders are what the feed can actually support.
     playerNote: 'College player stats are limited to league leaders — the public feed '
       + 'does not publish a full per-player season table.',
-    sortableSeasonFields: [
-      'totalPointsPerGame', 'totalYards', 'passingYards', 'rushingYards',
-      'yardsPerGame', 'completionPct', 'opp_totalPointsPerGame', 'opp_totalYards',
-    ],
-    rankingsTable: 'power_rankings',
+    sortableSeasonFields: CFB_SEASON_SORT_FIELDS,
   },
 };
 
 export function getFootballSport(key: string): FootballSportConfig | null {
   return FOOTBALL_SPORTS[key?.toLowerCase()] || null;
+}
+
+/** Resolve a table's dataset name for a sport. */
+export function datasetFor(sport: FootballSportConfig, kind: DatasetKind): string {
+  return kind === 'season' ? sport.seasonDataset : sport.histDataset;
 }

--- a/src/config/football.config.ts
+++ b/src/config/football.config.ts
@@ -59,6 +59,15 @@ export interface FootballSportConfig {
    * say which teams are missing rather than showing an unexplained short table.
    */
   teamSeasonCoverage?: string;
+  /**
+   * Betting lines, joined on game_id to score the Vegas baseline.
+   *
+   * Null where the sport stores its spread on the prediction row instead — the NFL
+   * pipeline writes spread_line directly, because nflverse supplies it with the
+   * schedule. College needs a join because its lines come from a separate feed.
+   */
+  linesTable: string | null;
+  linesDataset: DatasetKind;
   /** Team metadata: abbreviations, colours, logos. */
   teamsTable: string | null;
   teamsDataset: DatasetKind;
@@ -150,6 +159,10 @@ export const FOOTBALL_SPORTS: Record<string, FootballSportConfig> = {
     teamSeasonTable: null,
     teamSeasonDataset: 'season',
     teamSeasonColumnCatalog: null,
+    // nflverse ships spread_line on the schedule, so it is already a column on
+    // nfl_season.game_predictions and needs no join.
+    linesTable: null,
+    linesDataset: 'season',
     teamsTable: 'teams',
     teamsDataset: 'hist',
     playerTable: 'player_season_stats',
@@ -212,6 +225,8 @@ export const FOOTBALL_SPORTS: Record<string, FootballSportConfig> = {
     teamSeasonColumnCatalog: 'cfb_team_season',
     teamSeasonCoverage: 'FBS only — the public feed does not publish an FCS season '
       + 'table, so FCS teams have no row here.',
+    linesTable: 'betting_lines',
+    linesDataset: 'season',
     // CFB has no team metadata table yet, so no logos or colours for college.
     teamsTable: null,
     teamsDataset: 'hist',

--- a/src/controllers/football-games.controller.ts
+++ b/src/controllers/football-games.controller.ts
@@ -1,0 +1,526 @@
+/**
+ * Schedule, live scoreboard and game detail for football.
+ *
+ * College only for now: these read CollegeFootballData, which publishes no NFL data
+ * (products are ["cfb","cbb"]). NFL equivalents need ESPN and are deliberately not
+ * faked here — an NFL request gets a note saying so rather than an empty page.
+ *
+ * Three endpoints, three different natures:
+ *
+ *   /schedule          upcoming and past fixtures. Slow-moving, long TTL.
+ *   /scoreboard        live scores, clock, possession. Short TTL, the polling hot path.
+ *   /games/:gameId     one game in full. Fans out upstream, so it is the expensive one.
+ *
+ * The game detail handler is the only place in the football stack that fans out. That is
+ * justified here and nowhere else: five sequential client round-trips against the
+ * frontend's 60s timeout, on a cold instance, is the realistic failure mode for a page
+ * someone opens from a score notification. It uses allSettled so one slow or
+ * unentitled feed degrades that panel instead of the page.
+ */
+
+import { Request, Response } from 'express';
+import { BigQuery } from '@google-cloud/bigquery';
+import { logger } from '../utils/logger';
+import { datasetFor } from '../config/football.config';
+import {
+  resolveSport,
+  isMissingTable,
+  respondUnavailable,
+} from '../utils/football-request';
+import {
+  cfbdGet,
+  CfbdTTL,
+  completedTTL,
+  isCfbdUnavailable,
+  hasApiKey,
+} from '../services/cfbd.service';
+import { serveCached, serveCachedDynamic } from '../utils/football-cache';
+import { getCacheKey } from '../utils/cache-keys';
+import { cacheService } from '../services/cache.service';
+
+const PROJECT = process.env.GCP_PROJECT_ID || 'hankstank';
+const bigquery = new BigQuery({ projectId: PROJECT });
+
+/** Classifications the site covers. CFBD also returns DII and DIII, which it does not. */
+const SITE_CLASSIFICATIONS = new Set(['fbs', 'fcs']);
+
+/** No feed and no table recognises this game id. */
+class GameNotFound extends Error {
+  constructor(gameId: string) {
+    super(`No game found for id ${gameId}`);
+    this.name = 'GameNotFound';
+  }
+}
+
+/** A panel we cannot even ask for, because the game's week is unknown. */
+class NeedsWeek extends Error {
+  constructor(panel: string) {
+    super(`Cannot load the ${panel} without knowing the game's week — `
+      + 'pass ?week= or wait for the pipeline to record this game.');
+    this.name = 'NeedsWeek';
+  }
+}
+
+function seasonParam(req: Request): number {
+  const raw = parseInt((req.query.season as string) || '', 10);
+  if (Number.isFinite(raw)) return raw;
+  const env = parseInt(process.env.CURRENT_SEASON || '', 10);
+  return Number.isFinite(env) ? env : new Date().getFullYear();
+}
+
+/** Only CFB has a live feed; say so plainly rather than returning an empty scoreboard. */
+function requireCollege(res: Response, sportKey: string, resource: string): boolean {
+  if (sportKey === 'cfb') return true;
+  res.json({
+    success: true,
+    data: [],
+    meta: {
+      sport: sportKey,
+      count: 0,
+      note: `Live ${resource} is college-only for now — the college feed publishes no `
+        + 'NFL data, so the NFL equivalent needs a separate source.',
+    },
+  });
+  return false;
+}
+
+/** One game, in the shape the scoreboard and schedule both present. */
+function normalizeScoreboardGame(g: any) {
+  return {
+    game_id: String(g.id),
+    start_date: g.startDate,
+    start_time_tbd: Boolean(g.startTimeTBD),
+    status: g.status,
+    period: g.period ?? null,
+    clock: g.clock ?? null,
+    situation: g.situation ?? null,
+    possession: g.possession ?? null,
+    last_play: g.lastPlay ?? null,
+    tv: g.tv ?? null,
+    neutral_site: Boolean(g.neutralSite),
+    conference_game: Boolean(g.conferenceGame),
+    venue: g.venue
+      ? { name: g.venue.name, city: g.venue.city, state: g.venue.state }
+      : null,
+    weather: g.weather ?? null,
+    betting: g.betting ?? null,
+    home: {
+      // These names match the full display form already used as the key in
+      // cfb_historical.games and power_rankings, so they join without a crosswalk.
+      name: g.homeTeam?.name,
+      conference: g.homeTeam?.conference,
+      classification: g.homeTeam?.classification,
+      points: g.homeTeam?.points ?? null,
+      line_scores: g.homeTeam?.lineScores ?? null,
+      win_probability: g.homeTeam?.winProbability ?? null,
+    },
+    away: {
+      name: g.awayTeam?.name,
+      conference: g.awayTeam?.conference,
+      classification: g.awayTeam?.classification,
+      points: g.awayTeam?.points ?? null,
+      line_scores: g.awayTeam?.lineScores ?? null,
+      win_probability: g.awayTeam?.winProbability ?? null,
+    },
+  };
+}
+
+/**
+ * GET /api/football/:sport/scoreboard?season=&week=&division=
+ *
+ * The polling hot path. One upstream call covers every game in the week, so this stays
+ * cheap however many people are watching.
+ */
+export async function getScoreboard(req: Request, res: Response): Promise<void> {
+  const sport = resolveSport(req, res);
+  if (!sport) return;
+  if (!requireCollege(res, sport.key, 'scoreboard')) return;
+
+  if (!hasApiKey()) {
+    respondUnavailable(
+      res, sport, 'live scoreboard',
+      'Live scores need a CollegeFootballData API key, which is not configured here.',
+    );
+    return;
+  }
+
+  try {
+    const season = seasonParam(req);
+    const week = req.query.week ? parseInt(req.query.week as string, 10) : undefined;
+    const division = ((req.query.division as string) || '').toLowerCase();
+
+    const raw = await cfbdGet<any[]>(
+      '/scoreboard',
+      { year: season, week, classification: division || undefined },
+      CfbdTTL.scoreboard,
+    );
+
+    let games = (raw || []).map(normalizeScoreboardGame);
+    // CFBD returns DII and DIII alongside FBS/FCS; the site covers only the top two.
+    games = games.filter(
+      (g) => SITE_CLASSIFICATIONS.has(g.home.classification)
+        || SITE_CLASSIFICATIONS.has(g.away.classification),
+    );
+    if (division) {
+      games = games.filter(
+        (g) => g.home.classification === division || g.away.classification === division,
+      );
+    }
+
+    const live = games.filter((g) => g.status === 'in_progress').length;
+
+    res.set('Cache-Control', `public, max-age=${CfbdTTL.scoreboard}`);
+    res.json({
+      success: true,
+      data: games,
+      meta: {
+        sport: sport.key,
+        season,
+        week: week ?? null,
+        division: division || null,
+        count: games.length,
+        live,
+        source: 'collegefootballdata',
+      },
+    });
+  } catch (error: any) {
+    if (isCfbdUnavailable(error)) {
+      respondUnavailable(res, sport, 'live scoreboard', error.message);
+      return;
+    }
+    logger.error('football scoreboard failed', { sport: sport.key, error: error.message });
+    res.status(500).json({
+      success: false,
+      error: { code: 'SCOREBOARD_ERROR', message: 'Failed to load the scoreboard' },
+    });
+  }
+}
+
+/**
+ * GET /api/football/:sport/schedule?season=&week=&team=&division=
+ *
+ * Fixtures rather than scores. Served from the upstream schedule because the BigQuery
+ * games tables hold completed games only — there is nothing there for an upcoming week.
+ */
+export async function getSchedule(req: Request, res: Response): Promise<void> {
+  const sport = resolveSport(req, res);
+  if (!sport) return;
+  if (!requireCollege(res, sport.key, 'schedule')) return;
+
+  if (!hasApiKey()) {
+    respondUnavailable(
+      res, sport, 'schedule',
+      'Schedules need a CollegeFootballData API key, which is not configured here.',
+    );
+    return;
+  }
+
+  const season = seasonParam(req);
+  const week = req.query.week ? parseInt(req.query.week as string, 10) : undefined;
+  const team = (req.query.team as string) || undefined;
+  const division = ((req.query.division as string) || '').toLowerCase() || undefined;
+
+  const cacheKey = getCacheKey('ftbl:cfb:sched', { season, week, team, division });
+
+  try {
+    await serveCached(res, cacheKey, CfbdTTL.schedule, async () => {
+      const raw = await cfbdGet<any[]>(
+        '/games',
+        { year: season, week, team, classification: division },
+        CfbdTTL.schedule,
+      );
+
+      const games = (raw || [])
+        .filter((g) => SITE_CLASSIFICATIONS.has(g.homeClassification)
+          || SITE_CLASSIFICATIONS.has(g.awayClassification))
+        .map((g) => ({
+          game_id: String(g.id),
+          season: g.season,
+          week: g.week,
+          season_type: g.seasonType,
+          start_date: g.startDate,
+          start_time_tbd: Boolean(g.startTimeTBD),
+          completed: Boolean(g.completed),
+          neutral_site: Boolean(g.neutralSite),
+          conference_game: Boolean(g.conferenceGame),
+          venue: g.venue ?? null,
+          // NOTE: /games returns the school ("TCU") where /scoreboard returns the full
+          // display name ("TCU Horned Frogs"). The display name is what the BigQuery
+          // tables key on, so anything joining these rows must join on game_id.
+          home_school: g.homeTeam,
+          home_conference: g.homeConference,
+          home_classification: g.homeClassification,
+          home_points: g.homePoints ?? null,
+          home_pregame_elo: g.homePregameElo ?? null,
+          away_school: g.awayTeam,
+          away_conference: g.awayConference,
+          away_classification: g.awayClassification,
+          away_points: g.awayPoints ?? null,
+          away_pregame_elo: g.awayPregameElo ?? null,
+          excitement_index: g.excitementIndex ?? null,
+        }))
+        .sort((a, b) => String(a.start_date).localeCompare(String(b.start_date)));
+
+      return {
+        success: true,
+        data: games,
+        meta: {
+          sport: sport.key,
+          season,
+          week: week ?? null,
+          division: division || null,
+          count: games.length,
+          upcoming: games.filter((g) => !g.completed).length,
+          source: 'collegefootballdata',
+          join_note: 'Team fields here are school names; join to BigQuery on game_id.',
+        },
+      };
+    });
+  } catch (error: any) {
+    if (isCfbdUnavailable(error)) {
+      respondUnavailable(res, sport, 'schedule', error.message);
+      return;
+    }
+    logger.error('football schedule failed', { sport: sport.key, error: error.message });
+    res.status(500).json({
+      success: false,
+      error: { code: 'SCHEDULE_ERROR', message: 'Failed to load the schedule' },
+    });
+  }
+}
+
+/**
+ * Which week a game belongs to.
+ *
+ * Needed because /games/teams, /games/players and /drives all require week (or team, or
+ * conference) alongside year — an id alone fails validation — and /scoreboard does not
+ * return a week field. The client normally knows it, having navigated from a scoreboard
+ * or schedule, so it is a query param first; BigQuery is the fallback for a bookmarked
+ * link. Where neither answers, the week-dependent panels are skipped with a note rather
+ * than the whole page failing.
+ */
+async function resolveWeek(
+  sport: any, gameId: string, fromQuery: string | undefined,
+): Promise<number | null> {
+  const asked = parseInt(fromQuery || '', 10);
+  if (Number.isFinite(asked)) return asked;
+
+  for (const [dataset, table] of [
+    [sport.histDataset, sport.gamesTable],
+    [sport.seasonDataset, sport.predictionsTable],
+  ]) {
+    try {
+      const [rows] = await bigquery.query({
+        query: `SELECT week FROM \`${PROJECT}.${dataset}.${table}\`
+                WHERE game_id = @gameId LIMIT 1`,
+        params: { gameId },
+      });
+      if (rows[0]?.week !== undefined && rows[0]?.week !== null) {
+        return Number(rows[0].week);
+      }
+    } catch (error: any) {
+      logger.debug('week lookup failed', { table, error: error?.message });
+    }
+  }
+  return null;
+}
+
+/**
+ * Drives for one game.
+ *
+ * /drives cannot be filtered to a game — it takes year and week, and a single week is
+ * about 1,700 drives and 900KB to extract the ~20 that belong to one game. So the raw
+ * response is deliberately not cached (it exceeds the store's size limit anyway); the
+ * filtered slice is cached under a game-specific key instead, which is what makes the
+ * second view of a game cheap.
+ */
+async function gameDrives(
+  gameId: string, season: number, week: number, ttl: number,
+): Promise<any[]> {
+  const sliceKey = getCacheKey('cfbd:drives:game', { gameId });
+  try {
+    const hit = await cacheService.get<any[]>(sliceKey);
+    if (hit) return hit;
+  } catch { /* a cache miss is not a failure */ }
+
+  const all = await cfbdGet<any[]>('/drives', { year: season, week }, ttl);
+  const mine = (all || []).filter((d) => String(d.gameId) === gameId);
+
+  try {
+    await cacheService.set(sliceKey, mine, ttl);
+  } catch { /* best effort */ }
+  return mine;
+}
+
+/** The model's own pick for this game, if the pipeline has written one. */
+async function loadPrediction(sport: any, gameId: string): Promise<any | null> {
+  const dataset = sport.seasonDataset;
+  const [rows] = await bigquery.query({
+    query: `SELECT * FROM \`${PROJECT}.${dataset}.${sport.predictionsTable}\`
+            WHERE game_id = @gameId LIMIT 1`,
+    params: { gameId },
+  });
+  return rows[0] || null;
+}
+
+/**
+ * GET /api/football/:sport/games/:gameId
+ *
+ * One game, assembled from every feed that has something to say about it. Each panel is
+ * independent: a game with no model pick, or a box score the tier does not cover, still
+ * renders everything else. `meta.available` and `meta.missing` tell the client which
+ * panels to draw, generalising the meta.note convention to a multi-part payload.
+ */
+export async function getGameDetail(req: Request, res: Response): Promise<void> {
+  const sport = resolveSport(req, res);
+  if (!sport) return;
+  if (!requireCollege(res, sport.key, 'game detail')) return;
+
+  const gameId = String(req.params.gameId || '').trim();
+  if (!/^\d{4,12}$/.test(gameId)) {
+    res.status(400).json({
+      success: false,
+      error: { code: 'BAD_GAME_ID', message: 'gameId must be a numeric game id' },
+    });
+    return;
+  }
+
+  if (!hasApiKey()) {
+    respondUnavailable(
+      res, sport, 'game detail',
+      'Game detail needs a CollegeFootballData API key, which is not configured here.',
+    );
+    return;
+  }
+
+  const season = seasonParam(req);
+  // Keyed on the game, not on the week hint: the same game must not occupy two entries
+  // just because one caller happened to pass ?week=.
+  const bodyKey = getCacheKey('ftbl:cfb:game', { gameId, season });
+
+  try {
+    await serveCachedDynamic(res, bodyKey, async () => {
+    const week = await resolveWeek(sport, gameId, req.query.week as string);
+
+    // Fetched first and alone: it tells us whether the game is finished, which decides
+    // how long everything else may be cached. Narrowed by week when we know it.
+    const board = await cfbdGet<any[]>(
+      '/scoreboard',
+      week !== null ? { year: season, week } : { year: season },
+      CfbdTTL.scoreboard,
+    );
+    const boardGame = (board || []).find((g) => String(g.id) === gameId) || null;
+    const isCompleted = boardGame?.status === 'completed';
+    const boxTTL = completedTTL(CfbdTTL.boxScore, isCompleted);
+
+    // Week-dependent panels. /games/teams, /games/players and /drives all reject a bare
+    // year+id, so without a week these cannot be asked for at all.
+    const weekScoped = week === null
+      ? [
+        Promise.reject(new NeedsWeek('team box score')),
+        Promise.reject(new NeedsWeek('player box score')),
+        Promise.reject(new NeedsWeek('drives')),
+      ]
+      : [
+        cfbdGet<any[]>('/games/teams', { year: season, week, id: gameId }, boxTTL),
+        cfbdGet<any[]>('/games/players', { year: season, week, id: gameId }, boxTTL),
+        gameDrives(gameId, season, week,
+          completedTTL(CfbdTTL.drives, isCompleted)),
+      ];
+
+    const settled = await Promise.allSettled([
+      cfbdGet<any[]>('/metrics/wp', { gameId },
+        completedTTL(CfbdTTL.winProbability, isCompleted)),
+      ...weekScoped,
+      isCompleted
+        ? Promise.resolve([])
+        : cfbdGet<any[]>('/live/plays', { gameId }, CfbdTTL.livePlays),
+      loadPrediction(sport, gameId),
+    ]);
+
+    const panels = ['win_probability', 'team_box', 'player_box', 'drives',
+      'live_plays', 'prediction'];
+    const data: Record<string, any> = {};
+    const available: string[] = [];
+    const missing: string[] = [];
+    const notes: Record<string, string> = {};
+
+    settled.forEach((result, i) => {
+      const panel = panels[i];
+      if (result.status === 'fulfilled') {
+        const value = result.value;
+        const empty = value === null
+          || (Array.isArray(value) && value.length === 0);
+        data[panel] = value;
+        if (empty) {
+          missing.push(panel);
+        } else {
+          available.push(panel);
+        }
+        return;
+      }
+      const reason: any = result.reason;
+      data[panel] = null;
+      missing.push(panel);
+      if (isCfbdUnavailable(reason) || reason?.name === 'NeedsWeek') {
+        notes[panel] = reason.message;
+      } else if (isMissingTable(reason)) {
+        notes[panel] = 'Not built yet.';
+      } else {
+        // A real failure in one panel is logged but must not fail the page.
+        logger.warn('football game detail panel failed', {
+          sport: sport.key, gameId, panel, error: reason?.message,
+        });
+        notes[panel] = 'Temporarily unavailable.';
+      }
+    });
+
+    // Nothing anywhere recognises this id. Thrown rather than answered here so a 404
+    // is never cached as if it were a game.
+    if (!boardGame && !available.length) {
+      throw new GameNotFound(gameId);
+    }
+
+    return {
+      ttl: isCompleted ? 86400 : CfbdTTL.scoreboard,
+      body: {
+        success: true,
+        data: {
+          game: boardGame ? normalizeScoreboardGame(boardGame) : null,
+          ...data,
+        },
+        meta: {
+          sport: sport.key,
+          season,
+          game_id: gameId,
+          week,
+          completed: isCompleted,
+          available,
+          missing,
+          ...(Object.keys(notes).length ? { notes } : {}),
+          source: 'collegefootballdata',
+        },
+      },
+    };
+    });
+  } catch (error: any) {
+    if (error?.name === 'GameNotFound') {
+      res.status(404).json({
+        success: false,
+        error: { code: 'GAME_NOT_FOUND', message: error.message },
+      });
+      return;
+    }
+    if (isCfbdUnavailable(error)) {
+      respondUnavailable(res, sport, 'game detail', error.message);
+      return;
+    }
+    logger.error('football game detail failed', {
+      sport: sport.key, gameId, error: error.message,
+    });
+    res.status(500).json({
+      success: false,
+      error: { code: 'GAME_DETAIL_ERROR', message: 'Failed to load the game' },
+    });
+  }
+}

--- a/src/controllers/football-games.controller.ts
+++ b/src/controllers/football-games.controller.ts
@@ -136,7 +136,7 @@ export async function getScoreboard(req: Request, res: Response): Promise<void> 
   if (!sport) return;
   if (!requireCollege(res, sport.key, 'scoreboard')) return;
 
-  if (!hasApiKey()) {
+  if (!(await hasApiKey())) {
     respondUnavailable(
       res, sport, 'live scoreboard',
       'Live scores need a CollegeFootballData API key, which is not configured here.',
@@ -207,7 +207,7 @@ export async function getSchedule(req: Request, res: Response): Promise<void> {
   if (!sport) return;
   if (!requireCollege(res, sport.key, 'schedule')) return;
 
-  if (!hasApiKey()) {
+  if (!(await hasApiKey())) {
     respondUnavailable(
       res, sport, 'schedule',
       'Schedules need a CollegeFootballData API key, which is not configured here.',
@@ -385,7 +385,7 @@ export async function getGameDetail(req: Request, res: Response): Promise<void> 
     return;
   }
 
-  if (!hasApiKey()) {
+  if (!(await hasApiKey())) {
     respondUnavailable(
       res, sport, 'game detail',
       'Game detail needs a CollegeFootballData API key, which is not configured here.',

--- a/src/controllers/football-stats.controller.ts
+++ b/src/controllers/football-stats.controller.ts
@@ -15,15 +15,15 @@
  * than from a hardcoded list of column names.
  */
 
-import { Request, Response } from 'express';
-import { BigQuery } from '@google-cloud/bigquery';
-import { logger } from '../utils/logger';
-import { datasetFor, FootballSportConfig } from '../config/football.config';
+import { Request, Response } from "express";
+import { BigQuery } from "@google-cloud/bigquery";
+import { logger } from "../utils/logger";
+import { datasetFor, FootballSportConfig } from "../config/football.config";
 import {
   getColumnCatalog,
   resolveColumns,
   ColumnSpec,
-} from '../config/football-columns.config';
+} from "../config/football-columns.config";
 import {
   resolveSport,
   isMissingTable,
@@ -31,9 +31,16 @@ import {
   parsePaging,
   pickSort,
   sortDirection,
-} from '../utils/football-request';
+} from "../utils/football-request";
+import {
+  serveCached,
+  seasonAwareTTL,
+  currentSeason,
+  FootballCacheKeys,
+  FootballCacheTTL,
+} from "../utils/football-cache";
 
-const PROJECT = process.env.GCP_PROJECT_ID || 'hankstank';
+const PROJECT = process.env.GCP_PROJECT_ID || "hankstank";
 const bigquery = new BigQuery({ projectId: PROJECT });
 
 /** Serialise the catalog for the wire. snake_case to match the rest of meta. */
@@ -69,38 +76,43 @@ export async function searchTeamSeasonStats(
   if (!sport) return;
 
   if (!sport.teamSeasonTable || !sport.teamSeasonColumnCatalog) {
-    respondUnavailable(res, sport, 'per-team season stats');
+    respondUnavailable(res, sport, "per-team season stats");
     return;
   }
 
   const catalog = getColumnCatalog(sport.teamSeasonColumnCatalog);
   if (!catalog) {
-    logger.error('football season catalog missing', {
-      sport: sport.key, catalog: sport.teamSeasonColumnCatalog,
+    logger.error("football season catalog missing", {
+      sport: sport.key,
+      catalog: sport.teamSeasonColumnCatalog,
     });
     res.status(500).json({
       success: false,
-      error: { code: 'CATALOG_ERROR', message: 'Failed to load column catalog' },
+      error: {
+        code: "CATALOG_ERROR",
+        message: "Failed to load column catalog",
+      },
     });
     return;
   }
 
   const q = req.query as Record<string, string>;
   const allowedSort = sport.sortableSeasonFields || [];
-  const sort = pickSort(q.sort, allowedSort, allowedSort[0] || 'season');
+  const sort = pickSort(q.sort, allowedSort, allowedSort[0] || "season");
   if (!sort) {
     res.status(400).json({
       success: false,
       error: {
-        code: 'INVALID_SORT',
-        message: `sort must be one of: ${allowedSort.join(', ')}`,
+        code: "INVALID_SORT",
+        message: `sort must be one of: ${allowedSort.join(", ")}`,
       },
     });
     return;
   }
 
   const { columns, unknown } = resolveColumns(catalog, {
-    fields: q.fields, group: q.group,
+    fields: q.fields,
+    group: q.group,
   });
 
   // The sort column has to be in the projection or BigQuery cannot order by it.
@@ -114,7 +126,7 @@ export async function searchTeamSeasonStats(
   // Params the table cannot satisfy. Ignored rather than passed to SQL: the season
   // table has no week or division column, and filtering on one raises
   // `Unrecognized name`, which reads as a server error rather than a bad request.
-  const ignored = ['week', 'division'].filter((p) => q[p] !== undefined);
+  const ignored = ["week", "division"].filter((p) => q[p] !== undefined);
 
   try {
     const { limit, offset } = parsePaging(q, { limit: 50, max: 200 });
@@ -124,79 +136,109 @@ export async function searchTeamSeasonStats(
     const params: Record<string, any> = { limit, offset };
 
     if (q.season) {
-      filters.push('season = @season');
+      filters.push("season = @season");
       params.season = parseInt(q.season, 10);
     }
     if (q.team) {
-      filters.push('team = @team');
+      filters.push("team = @team");
       params.team = q.team;
     }
     if (q.search) {
-      filters.push('(LOWER(team) LIKE @search OR LOWER(team_abbr) LIKE @search)');
+      filters.push(
+        "(LOWER(team) LIKE @search OR LOWER(team_abbr) LIKE @search)",
+      );
       params.search = `%${q.search.toLowerCase()}%`;
     }
 
-    const where = filters.length ? `WHERE ${filters.join(' AND ')}` : '';
+    const where = filters.length ? `WHERE ${filters.join(" AND ")}` : "";
     const dataset = datasetFor(sport, sport.teamSeasonDataset);
     const table = `\`${PROJECT}.${dataset}.${sport.teamSeasonTable}\``;
-    const select = projection.map((c) => quoteIdent(c.key)).join(', ');
+    const select = projection.map((c) => quoteIdent(c.key)).join(", ");
 
-    const [rows] = await bigquery.query({
-      query: `SELECT ${select} FROM ${table} ${where} `
-        + `ORDER BY ${quoteIdent(sort)} ${dir} LIMIT @limit OFFSET @offset`,
-      params,
+    const season = q.season ? parseInt(q.season, 10) : undefined;
+    const cacheKey = FootballCacheKeys.teamSeason(sport.key, {
+      season: q.season,
+      team: q.team,
+      search: q.search,
+      group: q.group,
+      fields: q.fields,
+      sort,
+      dir,
+      limit,
+      offset,
     });
-    const [[{ total }]] = await bigquery.query({
-      query: `SELECT COUNT(*) AS total FROM ${table} ${where}`,
-      params,
-    });
+    const ttl = seasonAwareTTL(
+      FootballCacheTTL.teamSeason,
+      season,
+      currentSeason(),
+    );
 
-    res.json({
-      success: true,
-      data: rows,
-      meta: {
-        sport: sport.key,
-        label: sport.label,
-        scope: 'season',
-        total,
-        count: rows.length,
-        limit,
-        offset,
-        sort,
-        direction: dir,
-        sortable_fields: allowedSort,
-        group: q.fields ? null : (q.group || 'core'),
-        groups: catalog.groups.map((gr) => ({
-          key: gr.key,
-          label: gr.label,
-          count: catalog.columns.filter((c) => c.group === gr.key).length,
-        })),
-        columns: wireColumns(projection),
-        coverage: sport.teamSeasonCoverage || null,
-        week_endpoint: sport.statsTable
-          ? `/api/football/${sport.key}/stats/teams`
-          : null,
-        ...(ignored.length ? { ignored_params: ignored } : {}),
-        ...(unknown.length ? { unknown_fields: unknown } : {}),
-      },
+    await serveCached(res, cacheKey, ttl, async () => {
+      const [rows] = await bigquery.query({
+        query:
+          `SELECT ${select} FROM ${table} ${where} ` +
+          `ORDER BY ${quoteIdent(sort)} ${dir} LIMIT @limit OFFSET @offset`,
+        params,
+      });
+      const [[{ total }]] = await bigquery.query({
+        query: `SELECT COUNT(*) AS total FROM ${table} ${where}`,
+        params,
+      });
+
+      return {
+        success: true,
+        data: rows,
+        meta: {
+          sport: sport.key,
+          label: sport.label,
+          scope: "season",
+          total,
+          count: rows.length,
+          limit,
+          offset,
+          sort,
+          direction: dir,
+          sortable_fields: allowedSort,
+          group: q.fields ? null : q.group || "core",
+          groups: catalog.groups.map((gr) => ({
+            key: gr.key,
+            label: gr.label,
+            count: catalog.columns.filter((c) => c.group === gr.key).length,
+          })),
+          columns: wireColumns(projection),
+          coverage: sport.teamSeasonCoverage || null,
+          week_endpoint: sport.statsTable
+            ? `/api/football/${sport.key}/stats/teams`
+            : null,
+          ...(ignored.length ? { ignored_params: ignored } : {}),
+          ...(unknown.length ? { unknown_fields: unknown } : {}),
+        },
+      };
     });
   } catch (error: any) {
     if (isMissingTable(error)) {
-      logger.warn('football season stats table unavailable', {
-        sport: sport.key, error: error.message,
+      logger.warn("football season stats table unavailable", {
+        sport: sport.key,
+        error: error.message,
       });
       respondUnavailable(
-        res, sport, 'per-team season stats',
+        res,
+        sport,
+        "per-team season stats",
         `${sport.label} season stats are configured but not built yet.`,
       );
       return;
     }
-    logger.error('football season stats search failed', {
-      sport: sport.key, error: error.message,
+    logger.error("football season stats search failed", {
+      sport: sport.key,
+      error: error.message,
     });
     res.status(500).json({
       success: false,
-      error: { code: 'STATS_ERROR', message: 'Failed to search team season stats' },
+      error: {
+        code: "STATS_ERROR",
+        message: "Failed to search team season stats",
+      },
     });
   }
 }
@@ -218,7 +260,7 @@ export async function getTeams(req: Request, res: Response): Promise<void> {
   if (!sport) return;
 
   if (!sport.teamsTable) {
-    respondUnavailable(res, sport, 'team metadata');
+    respondUnavailable(res, sport, "team metadata");
     return;
   }
 
@@ -236,7 +278,7 @@ export async function getTeams(req: Request, res: Response): Promise<void> {
     // nfl_historical.teams carries 36 rows for 32 clubs: relocated franchises
     // (OAK, SD, STL) keep their historical abbreviations. Anything rendering a current
     // league list wants the 32, so restrict to clubs that appear in the newest season.
-    const activeOnly = (q.active ?? 'true').toLowerCase() !== 'false';
+    const activeOnly = (q.active ?? "true").toLowerCase() !== "false";
     if (activeOnly) {
       filters.push(`team_abbr IN (
         SELECT home_team FROM ${games}
@@ -247,79 +289,92 @@ export async function getTeams(req: Request, res: Response): Promise<void> {
       )`);
     }
     if (q.conference) {
-      filters.push('LOWER(team_conf) = @conference');
+      filters.push("LOWER(team_conf) = @conference");
       params.conference = q.conference.toLowerCase();
     }
     if (q.search) {
       filters.push(
-        '(LOWER(team_name) LIKE @search OR LOWER(team_abbr) LIKE @search '
-        + 'OR LOWER(team_nick) LIKE @search)',
+        "(LOWER(team_name) LIKE @search OR LOWER(team_abbr) LIKE @search " +
+          "OR LOWER(team_nick) LIKE @search)",
       );
       params.search = `%${q.search.toLowerCase()}%`;
     }
 
-    const where = filters.length ? `WHERE ${filters.join(' AND ')}` : '';
+    const where = filters.length ? `WHERE ${filters.join(" AND ")}` : "";
 
-    const [rows] = await bigquery.query({
-      query: `
+    const cacheKey = FootballCacheKeys.teams(sport.key, {
+      search: q.search,
+      conference: q.conference,
+      active: activeOnly,
+      limit,
+    });
+
+    await serveCached(res, cacheKey, FootballCacheTTL.teams, async () => {
+      const [rows] = await bigquery.query({
+        query: `
         SELECT team_abbr, team_name, team_nick, team_conf, team_division,
                team_color, team_color2, team_logo_espn, team_logo_squared,
                team_wordmark
         FROM ${table} ${where}
         ORDER BY team_name
         LIMIT @limit`,
-      params,
-    });
+        params,
+      });
 
-    const data = rows.map((r: any) => ({
-      key: r.team_abbr,
-      sport: sport.key,
-      abbr: r.team_abbr,
-      name: r.team_name,
-      nick: r.team_nick,
-      school: null,
-      conference: r.team_conf,
-      division: r.team_division,
-      classification: null,
-      primary_color: r.team_color,
-      secondary_color: r.team_color2,
-      logo: r.team_logo_espn,
-      logo_squared: r.team_logo_squared,
-      wordmark: r.team_wordmark,
-      // Every spelling the other football tables use for this team, deduped.
-      aliases: [...new Set(
-        [r.team_abbr, r.team_name, r.team_nick].filter(Boolean),
-      )],
-    }));
-
-    res.json({
-      success: true,
-      data,
-      meta: {
+      const data = rows.map((r: any) => ({
+        key: r.team_abbr,
         sport: sport.key,
-        label: sport.label,
-        count: data.length,
-        active: activeOnly,
-        source: 'nflverse',
-      },
+        abbr: r.team_abbr,
+        name: r.team_name,
+        nick: r.team_nick,
+        school: null,
+        conference: r.team_conf,
+        division: r.team_division,
+        classification: null,
+        primary_color: r.team_color,
+        secondary_color: r.team_color2,
+        logo: r.team_logo_espn,
+        logo_squared: r.team_logo_squared,
+        wordmark: r.team_wordmark,
+        // Every spelling the other football tables use for this team, deduped.
+        aliases: [
+          ...new Set([r.team_abbr, r.team_name, r.team_nick].filter(Boolean)),
+        ],
+      }));
+
+      return {
+        success: true,
+        data,
+        meta: {
+          sport: sport.key,
+          label: sport.label,
+          count: data.length,
+          active: activeOnly,
+          source: "nflverse",
+        },
+      };
     });
   } catch (error: any) {
     if (isMissingTable(error)) {
-      logger.warn('football teams table unavailable', {
-        sport: sport.key, error: error.message,
+      logger.warn("football teams table unavailable", {
+        sport: sport.key,
+        error: error.message,
       });
       respondUnavailable(
-        res, sport, 'team metadata',
+        res,
+        sport,
+        "team metadata",
         `${sport.label} team metadata is configured but not built yet.`,
       );
       return;
     }
-    logger.error('football teams query failed', {
-      sport: sport.key, error: error.message,
+    logger.error("football teams query failed", {
+      sport: sport.key,
+      error: error.message,
     });
     res.status(500).json({
       success: false,
-      error: { code: 'TEAMS_ERROR', message: 'Failed to load teams' },
+      error: { code: "TEAMS_ERROR", message: "Failed to load teams" },
     });
   }
 }

--- a/src/controllers/football-stats.controller.ts
+++ b/src/controllers/football-stats.controller.ts
@@ -1,0 +1,325 @@
+/**
+ * Football team-stats endpoints, split by grain rather than by sport.
+ *
+ *   /stats/teams          one row = team x week   (NFL: team_week_epa)
+ *   /stats/teams/season   one row = team x season (CFB: team_season_stats, 154 columns)
+ *
+ * They are separate routes because they are separate resources. A per-week game log and
+ * a season total filter differently — the season table has no `week` column at all — and
+ * one endpoint whose valid parameters change with :sport is how the college table ended
+ * up unreachable in the first place.
+ *
+ * Neither returns SELECT *. 154 columns times 200 rows is several MB of JSON per
+ * request, so callers get the `core` group by default and name what else they want. What
+ * came back is described in meta.columns, so the client renders from the response rather
+ * than from a hardcoded list of column names.
+ */
+
+import { Request, Response } from 'express';
+import { BigQuery } from '@google-cloud/bigquery';
+import { logger } from '../utils/logger';
+import { datasetFor, FootballSportConfig } from '../config/football.config';
+import {
+  getColumnCatalog,
+  resolveColumns,
+  ColumnSpec,
+} from '../config/football-columns.config';
+import {
+  resolveSport,
+  isMissingTable,
+  respondUnavailable,
+  parsePaging,
+  pickSort,
+  sortDirection,
+} from '../utils/football-request';
+
+const PROJECT = process.env.GCP_PROJECT_ID || 'hankstank';
+const bigquery = new BigQuery({ projectId: PROJECT });
+
+/** Serialise the catalog for the wire. snake_case to match the rest of meta. */
+function wireColumns(columns: ColumnSpec[]) {
+  return columns.map((c) => ({
+    key: c.key,
+    label: c.label,
+    group: c.group,
+    format: c.format,
+    higher_is_better: c.higherIsBetter ?? null,
+    opponent: c.opponent ?? false,
+  }));
+}
+
+/** Backtick-quote an identifier. Only ever called with allow-listed catalog keys. */
+function quoteIdent(key: string): string {
+  return `\`${key}\``;
+}
+
+/**
+ * GET /api/football/:sport/stats/teams/season
+ *
+ * Per-team season totals. Params: season, team, search, group, fields, sort, direction,
+ * limit, offset. `week` and `division` are accepted and ignored — the table carries
+ * neither — and echoed back in meta.ignored_params so a caller sending them is told
+ * rather than 500'd on `Unrecognized name: week`.
+ */
+export async function searchTeamSeasonStats(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const sport = resolveSport(req, res);
+  if (!sport) return;
+
+  if (!sport.teamSeasonTable || !sport.teamSeasonColumnCatalog) {
+    respondUnavailable(res, sport, 'per-team season stats');
+    return;
+  }
+
+  const catalog = getColumnCatalog(sport.teamSeasonColumnCatalog);
+  if (!catalog) {
+    logger.error('football season catalog missing', {
+      sport: sport.key, catalog: sport.teamSeasonColumnCatalog,
+    });
+    res.status(500).json({
+      success: false,
+      error: { code: 'CATALOG_ERROR', message: 'Failed to load column catalog' },
+    });
+    return;
+  }
+
+  const q = req.query as Record<string, string>;
+  const allowedSort = sport.sortableSeasonFields || [];
+  const sort = pickSort(q.sort, allowedSort, allowedSort[0] || 'season');
+  if (!sort) {
+    res.status(400).json({
+      success: false,
+      error: {
+        code: 'INVALID_SORT',
+        message: `sort must be one of: ${allowedSort.join(', ')}`,
+      },
+    });
+    return;
+  }
+
+  const { columns, unknown } = resolveColumns(catalog, {
+    fields: q.fields, group: q.group,
+  });
+
+  // The sort column has to be in the projection or BigQuery cannot order by it.
+  const projected = new Map(columns.map((c) => [c.key, c]));
+  if (!projected.has(sort)) {
+    const spec = catalog.columns.find((c) => c.key === sort);
+    if (spec) projected.set(sort, spec);
+  }
+  const projection = [...projected.values()];
+
+  // Params the table cannot satisfy. Ignored rather than passed to SQL: the season
+  // table has no week or division column, and filtering on one raises
+  // `Unrecognized name`, which reads as a server error rather than a bad request.
+  const ignored = ['week', 'division'].filter((p) => q[p] !== undefined);
+
+  try {
+    const { limit, offset } = parsePaging(q, { limit: 50, max: 200 });
+    const dir = sortDirection(q.direction);
+
+    const filters: string[] = [];
+    const params: Record<string, any> = { limit, offset };
+
+    if (q.season) {
+      filters.push('season = @season');
+      params.season = parseInt(q.season, 10);
+    }
+    if (q.team) {
+      filters.push('team = @team');
+      params.team = q.team;
+    }
+    if (q.search) {
+      filters.push('(LOWER(team) LIKE @search OR LOWER(team_abbr) LIKE @search)');
+      params.search = `%${q.search.toLowerCase()}%`;
+    }
+
+    const where = filters.length ? `WHERE ${filters.join(' AND ')}` : '';
+    const dataset = datasetFor(sport, sport.teamSeasonDataset);
+    const table = `\`${PROJECT}.${dataset}.${sport.teamSeasonTable}\``;
+    const select = projection.map((c) => quoteIdent(c.key)).join(', ');
+
+    const [rows] = await bigquery.query({
+      query: `SELECT ${select} FROM ${table} ${where} `
+        + `ORDER BY ${quoteIdent(sort)} ${dir} LIMIT @limit OFFSET @offset`,
+      params,
+    });
+    const [[{ total }]] = await bigquery.query({
+      query: `SELECT COUNT(*) AS total FROM ${table} ${where}`,
+      params,
+    });
+
+    res.json({
+      success: true,
+      data: rows,
+      meta: {
+        sport: sport.key,
+        label: sport.label,
+        scope: 'season',
+        total,
+        count: rows.length,
+        limit,
+        offset,
+        sort,
+        direction: dir,
+        sortable_fields: allowedSort,
+        group: q.fields ? null : (q.group || 'core'),
+        groups: catalog.groups.map((gr) => ({
+          key: gr.key,
+          label: gr.label,
+          count: catalog.columns.filter((c) => c.group === gr.key).length,
+        })),
+        columns: wireColumns(projection),
+        coverage: sport.teamSeasonCoverage || null,
+        week_endpoint: sport.statsTable
+          ? `/api/football/${sport.key}/stats/teams`
+          : null,
+        ...(ignored.length ? { ignored_params: ignored } : {}),
+        ...(unknown.length ? { unknown_fields: unknown } : {}),
+      },
+    });
+  } catch (error: any) {
+    if (isMissingTable(error)) {
+      logger.warn('football season stats table unavailable', {
+        sport: sport.key, error: error.message,
+      });
+      respondUnavailable(
+        res, sport, 'per-team season stats',
+        `${sport.label} season stats are configured but not built yet.`,
+      );
+      return;
+    }
+    logger.error('football season stats search failed', {
+      sport: sport.key, error: error.message,
+    });
+    res.status(500).json({
+      success: false,
+      error: { code: 'STATS_ERROR', message: 'Failed to search team season stats' },
+    });
+  }
+}
+
+/**
+ * GET /api/football/:sport/teams
+ *
+ * Team metadata — abbreviation, names, conference, colours, logos. Written by the ML
+ * pipeline and until now unreachable, which is why football cards show plain team names.
+ *
+ * The row shape is canonical rather than nflverse's, so a second sport can satisfy it
+ * without the client learning two vocabularies. `aliases` is built here on purpose: the
+ * other football tables disagree about what a team is called — predictions carry
+ * "Ohio State Buckeyes", rankings carry "Ohio State", team_week_epa carries "PHI" — and
+ * one matcher in one place beats three in the client.
+ */
+export async function getTeams(req: Request, res: Response): Promise<void> {
+  const sport = resolveSport(req, res);
+  if (!sport) return;
+
+  if (!sport.teamsTable) {
+    respondUnavailable(res, sport, 'team metadata');
+    return;
+  }
+
+  const q = req.query as Record<string, string>;
+
+  try {
+    const { limit } = parsePaging(q, { limit: 400, max: 400 });
+    const dataset = datasetFor(sport, sport.teamsDataset);
+    const table = `\`${PROJECT}.${dataset}.${sport.teamsTable}\``;
+    const games = `\`${PROJECT}.${sport.histDataset}.${sport.gamesTable}\``;
+
+    const filters: string[] = [];
+    const params: Record<string, any> = { limit };
+
+    // nfl_historical.teams carries 36 rows for 32 clubs: relocated franchises
+    // (OAK, SD, STL) keep their historical abbreviations. Anything rendering a current
+    // league list wants the 32, so restrict to clubs that appear in the newest season.
+    const activeOnly = (q.active ?? 'true').toLowerCase() !== 'false';
+    if (activeOnly) {
+      filters.push(`team_abbr IN (
+        SELECT home_team FROM ${games}
+        WHERE season = (SELECT MAX(season) FROM ${games})
+        UNION DISTINCT
+        SELECT away_team FROM ${games}
+        WHERE season = (SELECT MAX(season) FROM ${games})
+      )`);
+    }
+    if (q.conference) {
+      filters.push('LOWER(team_conf) = @conference');
+      params.conference = q.conference.toLowerCase();
+    }
+    if (q.search) {
+      filters.push(
+        '(LOWER(team_name) LIKE @search OR LOWER(team_abbr) LIKE @search '
+        + 'OR LOWER(team_nick) LIKE @search)',
+      );
+      params.search = `%${q.search.toLowerCase()}%`;
+    }
+
+    const where = filters.length ? `WHERE ${filters.join(' AND ')}` : '';
+
+    const [rows] = await bigquery.query({
+      query: `
+        SELECT team_abbr, team_name, team_nick, team_conf, team_division,
+               team_color, team_color2, team_logo_espn, team_logo_squared,
+               team_wordmark
+        FROM ${table} ${where}
+        ORDER BY team_name
+        LIMIT @limit`,
+      params,
+    });
+
+    const data = rows.map((r: any) => ({
+      key: r.team_abbr,
+      sport: sport.key,
+      abbr: r.team_abbr,
+      name: r.team_name,
+      nick: r.team_nick,
+      school: null,
+      conference: r.team_conf,
+      division: r.team_division,
+      classification: null,
+      primary_color: r.team_color,
+      secondary_color: r.team_color2,
+      logo: r.team_logo_espn,
+      logo_squared: r.team_logo_squared,
+      wordmark: r.team_wordmark,
+      // Every spelling the other football tables use for this team, deduped.
+      aliases: [...new Set(
+        [r.team_abbr, r.team_name, r.team_nick].filter(Boolean),
+      )],
+    }));
+
+    res.json({
+      success: true,
+      data,
+      meta: {
+        sport: sport.key,
+        label: sport.label,
+        count: data.length,
+        active: activeOnly,
+        source: 'nflverse',
+      },
+    });
+  } catch (error: any) {
+    if (isMissingTable(error)) {
+      logger.warn('football teams table unavailable', {
+        sport: sport.key, error: error.message,
+      });
+      respondUnavailable(
+        res, sport, 'team metadata',
+        `${sport.label} team metadata is configured but not built yet.`,
+      );
+      return;
+    }
+    logger.error('football teams query failed', {
+      sport: sport.key, error: error.message,
+    });
+    res.status(500).json({
+      success: false,
+      error: { code: 'TEAMS_ERROR', message: 'Failed to load teams' },
+    });
+  }
+}

--- a/src/controllers/football.controller.ts
+++ b/src/controllers/football.controller.ts
@@ -68,6 +68,30 @@ export async function getPredictions(req: Request, res: Response): Promise<void>
   }
 }
 
+/**
+ * A prediction-row source that always exposes `spread_line`.
+ *
+ * The join is deduplicated to one row per game. A game carries one line per sportsbook,
+ * and the ingest already collapses providers to a median — but joining without a
+ * guarantee of uniqueness would silently multiply prediction rows and corrupt every
+ * average while still returning success, so the constraint is asserted here too.
+ */
+function predictionSource(sport: FootballSportConfig): string {
+  const preds = `\`${PROJECT}.${sport.seasonDataset}.${sport.predictionsTable}\``;
+  if (!sport.linesTable) return `SELECT * FROM ${preds}`;
+
+  const lines = `\`${PROJECT}.${datasetFor(sport, sport.linesDataset)}.`
+    + `${sport.linesTable}\``;
+  return `
+    SELECT p.*, l.spread_line
+    FROM ${preds} p
+    LEFT JOIN (
+      SELECT game_id, ANY_VALUE(spread_line) AS spread_line
+      FROM ${lines}
+      GROUP BY game_id
+    ) l USING (game_id)`;
+}
+
 /** GET /api/football/:sport/predictions/accuracy?season=&division= */
 export async function getAccuracy(req: Request, res: Response): Promise<void> {
   const sport = resolveSport(req, res);
@@ -84,12 +108,18 @@ export async function getAccuracy(req: Request, res: Response): Promise<void> {
       params.division = division;
     }
 
-    // Vegas baseline only exists where a spread was stored (NFL); CFB's free feed
-    // carries no lines, so the column is absent and the baseline comes back null.
-    const vegasExpr = sport.key === 'nfl'
-      ? `AVG(CASE WHEN spread_line IS NOT NULL AND spread_line != 0
-                  THEN IF((spread_line > 0) = (home_won = 1), 1.0, 0.0) END)`
-      : 'CAST(NULL AS FLOAT64)';
+    // One expression for every sport. Where a sport keeps its spread on the prediction
+    // row (the NFL, because nflverse ships it with the schedule) the source is the
+    // table itself; where the lines come from a separate feed (college) the source is a
+    // join. Either way `spread_line` is present and positive means the home side is
+    // favoured, so the scoring expression below stops caring which sport it is.
+    //
+    // This replaced a `sport.key === 'nfl'` test that hardcoded CAST(NULL) for college,
+    // which is why the site's Vegas bar was NFL-only.
+    const source = predictionSource(sport);
+
+    const vegasExpr = `AVG(CASE WHEN spread_line IS NOT NULL AND spread_line != 0
+                  THEN IF((spread_line > 0) = (home_won = 1), 1.0, 0.0) END)`;
 
     const sql = `
       SELECT
@@ -100,7 +130,7 @@ export async function getAccuracy(req: Request, res: Response): Promise<void> {
                IF((elo_home_win_prob > 0.5) = (home_won = 1), 1.0, 0.0)))
                                                      AS elo_accuracy,
         ${vegasExpr}                                 AS vegas_accuracy
-      FROM \`${PROJECT}.${sport.seasonDataset}.${sport.predictionsTable}\`
+      FROM (${source})
       WHERE season = @season AND prediction_correct IS NOT NULL ${extra.join(' ')}
     `;
 
@@ -119,6 +149,12 @@ export async function getAccuracy(req: Request, res: Response): Promise<void> {
     res.json({
       success: true,
       data: { sport: sport.key, season, division: division || null, overall, by_tier: tiers },
+      meta: {
+        sport: sport.key,
+        // False where the sport stores no lines at all, so the UI can say the bar is
+        // missing rather than silently omitting it.
+        has_vegas: Boolean(sport.linesTable) || sport.key === 'nfl',
+      },
     });
   } catch (error: any) {
     // A sport whose predictions table has not been built yet is an expected state, not
@@ -643,10 +679,14 @@ export async function getDiagnostics(req: Request, res: Response): Promise<void>
     if (fromWeek) { filters.push('week >= @fromWeek'); params.fromWeek = parseInt(fromWeek, 10); }
     if (toWeek) { filters.push('week <= @toWeek'); params.toWeek = parseInt(toWeek, 10); }
 
-    const table = `${PROJECT}.${sport.seasonDataset}.${sport.predictionsTable}`;
+    // Same source as the accuracy endpoint, so spread_line is present for both sports
+    // and the "against the closing line" panel works for college too. The subquery
+    // guarantees one row per game — a naive join on a per-sportsbook lines table would
+    // multiply these rows and corrupt every aggregate while still returning success,
+    // and at LIMIT 6000 against ~3,500 college predictions there is no headroom for it.
     const sql = `
       SELECT *
-      FROM \`${table}\`
+      FROM (${predictionSource(sport)})
       WHERE ${filters.join(' AND ')}
       ORDER BY season, week, game_date
       LIMIT 6000

--- a/src/controllers/football.controller.ts
+++ b/src/controllers/football.controller.ts
@@ -13,7 +13,7 @@ import { BigQuery } from '@google-cloud/bigquery';
 import { logger } from '../utils/logger';
 import { normalizeBigQueryTemporalValue } from '../utils/bq-normalize';
 import { FootballSportConfig, datasetFor } from '../config/football.config';
-import { getColumnCatalog } from '../config/football-columns.config';
+import { getColumnCatalog, resolveColumns } from '../config/football-columns.config';
 import {
   resolveSport,
   normalizeRow,
@@ -22,16 +22,6 @@ import {
 
 const PROJECT = process.env.GCP_PROJECT_ID || 'hankstank';
 const bigquery = new BigQuery({ projectId: PROJECT });
-
-// Sortable player columns, allow-listed because BigQuery cannot parameterize an
-// ORDER BY identifier and the value arrives from the query string.
-const NFL_PLAYER_SORT_FIELDS = [
-  'passing_yards', 'passing_tds', 'passing_epa', 'passing_interceptions',
-  'completions', 'attempts', 'rushing_yards', 'rushing_tds', 'carries',
-  'rushing_epa', 'receiving_yards', 'receiving_tds', 'receptions', 'targets',
-  'receiving_epa', 'def_sacks', 'def_tackles_solo', 'def_interceptions',
-  'def_pass_defended', 'games',
-];
 
 /** GET /api/football/:sport/predictions?season=&week=&team=&tier=&division= */
 export async function getPredictions(req: Request, res: Response): Promise<void> {
@@ -211,10 +201,21 @@ export async function searchTeamStats(req: Request, res: Response): Promise<void
       offset: parseInt(offset, 10) || 0,
     };
 
+    const physical = (key: string) => (sport.statsFieldMap || {})[key] || key;
+
     if (season) { filters.push('season = @season'); params.season = parseInt(season, 10); }
     if (week) { filters.push('week = @week'); params.week = parseInt(week, 10); }
-    if (team) { filters.push('team = @team'); params.team = team.toUpperCase(); }
-    if (search) { filters.push('LOWER(team) LIKE @search'); params.search = `%${search.toLowerCase()}%`; }
+    if (team) {
+      // College team names are full display names ("Ohio State Buckeyes"); NFL are
+      // abbreviations. Matching case-insensitively on a prefix serves both without the
+      // caller needing to know which convention a sport uses.
+      filters.push(`LOWER(\`${physical('team')}\`) LIKE @team`);
+      params.team = `${team.toLowerCase()}%`;
+    }
+    if (search) {
+      filters.push(`LOWER(\`${physical('team')}\`) LIKE @search`);
+      params.search = `%${search.toLowerCase()}%`;
+    }
 
     const where = filters.length ? `WHERE ${filters.join(' AND ')}` : '';
     const table =
@@ -226,13 +227,29 @@ export async function searchTeamStats(req: Request, res: Response): Promise<void
     // hardcoding one sport's column names.
     const catalog = getColumnCatalog(sport.statsColumnCatalog);
     const projection = catalog ? catalog.columns : [];
+    const fieldMap = sport.statsFieldMap || {};
+
+    // Physical column AS canonical name. This is the whole mechanism that lets one
+    // client table render both sports: the NFL table stores per-play EPA and the
+    // college one stores PPA, and the alias reconciles them here rather than in the UI.
     const select = projection.length
-      ? projection.map((c) => `\`${c.key}\``).join(', ')
+      ? projection
+        .map((c) => {
+          const physical = fieldMap[c.key] || c.key;
+          return physical === c.key
+            ? `\`${c.key}\``
+            : `\`${physical}\` AS \`${c.key}\``;
+        })
+        .join(', ')
       : '*';
+
+    // ORDER BY has to name the physical column; the allow-list validated the canonical
+    // one, so the interpolated value is still never caller-controlled.
+    const sortColumn = fieldMap[sort] || sort;
 
     const [rows] = await bigquery.query({
       query: `SELECT ${select} FROM ${table} ${where} `
-        + `ORDER BY \`${sort}\` ${dir} LIMIT @limit OFFSET @offset`,
+        + `ORDER BY \`${sortColumn}\` ${dir} LIMIT @limit OFFSET @offset`,
       params,
     });
     const [[{ total }]] = await bigquery.query({
@@ -361,7 +378,9 @@ export async function getLeaders(req: Request, res: Response): Promise<void> {
     }
 
     const category = (req.query.category as string) || '';
-    const limit = Math.min(parseInt((req.query.limit as string) || '400', 10), 500);
+    // Default sized to hold every board: college now publishes 17 categories at 25
+    // deep, which is 425 rows and overflowed the old 400.
+    const limit = Math.min(parseInt((req.query.limit as string) || '600', 10), 1200);
 
     const filters = ['season = @season'];
     const params: Record<string, any> = { season, limit };
@@ -379,11 +398,28 @@ export async function getLeaders(req: Request, res: Response): Promise<void> {
       params,
     });
 
-    const categories = Array.from(
-      new Map(
-        rows.map((r: any) => [r.category, r.category_label])
-      ).entries()
-    ).map(([key, label]) => ({ key, label }));
+    // Derived from a DISTINCT rather than from the rows just returned. Building the
+    // client's category tabs out of a limited page means a truncating limit silently
+    // drops whole boards from the UI, which is a bug that looks like missing data.
+    const [categoryRows] = await bigquery.query({
+      query: `SELECT DISTINCT category, category_label,
+                     ANY_VALUE(higher_is_better) AS higher_is_better,
+                     ANY_VALUE(qualifier) AS qualifier
+              FROM \`${table}\`
+              WHERE season = @season
+              GROUP BY category, category_label
+              ORDER BY category_label`,
+      params: { season },
+    });
+
+    const categories = categoryRows.map((r: any) => ({
+      key: r.category,
+      label: r.category_label,
+      higher_is_better: r.higher_is_better ?? null,
+      // Present where a board has a volume floor, so a short board can explain itself
+      // rather than looking broken.
+      qualifier: r.qualifier ?? null,
+    }));
 
     res.json({
       success: true,
@@ -448,16 +484,24 @@ export async function searchPlayers(req: Request, res: Response): Promise<void> 
     const offset = Math.max(parseInt((req.query.offset as string) || '0', 10), 0);
 
     // Sort is interpolated, not parameterized — BigQuery cannot bind an identifier — so
-    // it is checked against an allow-list. Never pass the raw value through.
-    const requested = (req.query.sort as string) || 'passing_yards';
-    const sort = NFL_PLAYER_SORT_FIELDS.includes(requested) ? requested : 'passing_yards';
+    // it is checked against the sport's allow-list. Never pass the raw value through.
+    const allowedSort = sport.playerSortFields;
+    const requested = (req.query.sort as string) || allowedSort[0];
+    const sort = allowedSort.includes(requested) ? requested : allowedSort[0];
     const dir = ((req.query.direction as string) || 'desc').toLowerCase() === 'asc'
       ? 'ASC' : 'DESC';
+
+    // The two sports name their identity columns differently — nflverse calls them
+    // player_display_name and recent_team, the college pivot calls them player_name and
+    // team — so the filters resolve through the sport's map rather than hardcoding one.
+    const pf = sport.playerFieldMap || {};
+    const nameCol = pf.player_name || 'player_name';
+    const teamCol = pf.team || 'team';
 
     const filters = ['season = @season'];
     const params: Record<string, any> = { season, limit, offset };
     if (search) {
-      filters.push('UPPER(player_display_name) LIKE @search');
+      filters.push(`UPPER(\`${nameCol}\`) LIKE @search`);
       params.search = `%${search.toUpperCase()}%`;
     }
     if (position) {
@@ -465,16 +509,41 @@ export async function searchPlayers(req: Request, res: Response): Promise<void> 
       params.position = position.toUpperCase();
     }
     if (team) {
-      filters.push('UPPER(recent_team) = @team');
-      params.team = team.toUpperCase();
+      filters.push(`UPPER(\`${teamCol}\`) LIKE @team`);
+      params.team = `${team.toUpperCase()}%`;
     }
 
     const table = `${PROJECT}.${sport.seasonDataset}.${sport.playerTable}`;
     const where = `WHERE ${filters.join(' AND ')}`;
 
+    const catalog = getColumnCatalog(sport.playerColumnCatalog);
+    // Same group/fields narrowing as the team endpoints: the NFL table is 148 columns
+    // wide, so a default that sends all of them would be the site's heaviest response.
+    const resolved = catalog
+      ? resolveColumns(catalog, {
+        fields: req.query.fields as string,
+        group: req.query.group as string,
+      })
+      : { columns: [], unknown: [] as string[] };
+
+    // The sort column has to be in the projection for BigQuery to order by it.
+    const picked = new Map(resolved.columns.map((c) => [c.key, c]));
+    if (catalog && !picked.has(sort)) {
+      const spec = catalog.columns.find((c) => c.key === sort);
+      if (spec) picked.set(sort, spec);
+    }
+    const projectionCols = [...picked.values()];
+
+    const projection = projectionCols.length
+      ? projectionCols.map((c) => {
+        const phys = pf[c.key] || c.key;
+        return phys === c.key ? `\`${c.key}\`` : `\`${phys}\` AS \`${c.key}\``;
+      }).join(', ')
+      : '*';
+
     const [rows] = await bigquery.query({
-      query: `SELECT * FROM \`${table}\` ${where}
-              ORDER BY ${sort} ${dir} NULLS LAST
+      query: `SELECT ${projection} FROM \`${table}\` ${where}
+              ORDER BY \`${pf[sort] || sort}\` ${dir} NULLS LAST
               LIMIT @limit OFFSET @offset`,
       params,
     });
@@ -495,7 +564,21 @@ export async function searchPlayers(req: Request, res: Response): Promise<void> 
         offset,
         sort,
         direction: dir,
-        sortable_fields: NFL_PLAYER_SORT_FIELDS,
+        sortable_fields: allowedSort,
+        columns: projectionCols.map((c) => ({
+          key: c.key, label: c.label, group: c.group, format: c.format,
+          higher_is_better: c.higherIsBetter ?? null,
+          opponent: c.opponent ?? false,
+        })),
+        groups: catalog
+          ? catalog.groups.map((gr) => ({
+            key: gr.key,
+            label: gr.label,
+            count: catalog.columns.filter((c) => c.group === gr.key).length,
+          }))
+          : [],
+        group: req.query.fields ? null : ((req.query.group as string) || 'core'),
+        ...(resolved.unknown.length ? { unknown_fields: resolved.unknown } : {}),
       },
     });
   } catch (error: any) {

--- a/src/controllers/football.controller.ts
+++ b/src/controllers/football.controller.ts
@@ -12,7 +12,13 @@ import { Request, Response } from 'express';
 import { BigQuery } from '@google-cloud/bigquery';
 import { logger } from '../utils/logger';
 import { normalizeBigQueryTemporalValue } from '../utils/bq-normalize';
-import { getFootballSport, FootballSportConfig } from '../config/football.config';
+import { FootballSportConfig, datasetFor } from '../config/football.config';
+import { getColumnCatalog } from '../config/football-columns.config';
+import {
+  resolveSport,
+  normalizeRow,
+  isMissingTable,
+} from '../utils/football-request';
 
 const PROJECT = process.env.GCP_PROJECT_ID || 'hankstank';
 const bigquery = new BigQuery({ projectId: PROJECT });
@@ -26,27 +32,6 @@ const NFL_PLAYER_SORT_FIELDS = [
   'receiving_epa', 'def_sacks', 'def_tackles_solo', 'def_interceptions',
   'def_pass_defended', 'games',
 ];
-
-function resolveSport(req: Request, res: Response): FootballSportConfig | null {
-  const key = (req.params.sport || 'nfl').toLowerCase();
-  const sport = getFootballSport(key);
-  if (!sport) {
-    res.status(404).json({
-      success: false,
-      error: { code: 'UNKNOWN_SPORT', message: `Unknown football sport: ${key}` },
-    });
-    return null;
-  }
-  return sport;
-}
-
-function normalizeRow(row: any): any {
-  return {
-    ...row,
-    game_date: normalizeBigQueryTemporalValue(row.game_date),
-    predicted_at: normalizeBigQueryTemporalValue(row.predicted_at),
-  };
-}
 
 /** GET /api/football/:sport/predictions?season=&week=&team=&tier=&division= */
 export async function getPredictions(req: Request, res: Response): Promise<void> {
@@ -146,6 +131,24 @@ export async function getAccuracy(req: Request, res: Response): Promise<void> {
       data: { sport: sport.key, season, division: division || null, overall, by_tier: tiers },
     });
   } catch (error: any) {
+    // A sport whose predictions table has not been built yet is an expected state, not
+    // an outage. Every other football handler already answered that with a note; this
+    // one went straight to 500, so a missing table read as a server error.
+    if (isMissingTable(error)) {
+      logger.warn('football accuracy table unavailable', {
+        sport: sport.key, error: error.message,
+      });
+      res.json({
+        success: true,
+        data: null,
+        meta: {
+          sport: sport.key,
+          label: sport.label,
+          note: `${sport.label} predictions are not built yet.`,
+        },
+      });
+      return;
+    }
     logger.error('football accuracy query failed', {
       sport: sport.key, error: error.message,
     });
@@ -162,12 +165,22 @@ export async function searchTeamStats(req: Request, res: Response): Promise<void
   if (!sport) return;
 
   if (!sport.statsTable) {
+    // Says what IS available rather than only what is not. The old wording — "no
+    // per-team advanced stats feed for this sport yet" — was already false: college
+    // season totals were sitting in BigQuery the whole time, just unreachable.
+    const seasonPath = sport.teamSeasonTable
+      ? `/api/football/${sport.key}/stats/teams/season`
+      : null;
     res.json({
       success: true,
       data: [],
       meta: {
-        sport: sport.key, total: 0, count: 0, sortable_fields: [],
-        note: 'No per-team advanced stats feed for this sport yet.',
+        sport: sport.key, label: sport.label, scope: 'week',
+        total: 0, count: 0, sortable_fields: [],
+        season_endpoint: seasonPath,
+        note: seasonPath
+          ? `${sport.label} has no per-week feed yet — season totals are at ${seasonPath}.`
+          : `${sport.label} has no per-week stats feed yet.`,
       },
     });
     return;
@@ -204,10 +217,22 @@ export async function searchTeamStats(req: Request, res: Response): Promise<void
     if (search) { filters.push('LOWER(team) LIKE @search'); params.search = `%${search.toLowerCase()}%`; }
 
     const where = filters.length ? `WHERE ${filters.join(' AND ')}` : '';
-    const table = `\`${PROJECT}.${sport.histDataset}.${sport.statsTable}\``;
+    const table =
+      `\`${PROJECT}.${datasetFor(sport, sport.statsDataset)}.${sport.statsTable}\``;
+
+    // Projected from the catalog rather than SELECT *. This table is only 17 columns,
+    // so the win is not payload size — it is that both stats endpoints now describe
+    // what they returned in meta.columns, and the client renders from that instead of
+    // hardcoding one sport's column names.
+    const catalog = getColumnCatalog(sport.statsColumnCatalog);
+    const projection = catalog ? catalog.columns : [];
+    const select = projection.length
+      ? projection.map((c) => `\`${c.key}\``).join(', ')
+      : '*';
 
     const [rows] = await bigquery.query({
-      query: `SELECT * FROM ${table} ${where} ORDER BY ${sort} ${dir} LIMIT @limit OFFSET @offset`,
+      query: `SELECT ${select} FROM ${table} ${where} `
+        + `ORDER BY \`${sort}\` ${dir} LIMIT @limit OFFSET @offset`,
       params,
     });
     const [[{ total }]] = await bigquery.query({
@@ -219,9 +244,28 @@ export async function searchTeamStats(req: Request, res: Response): Promise<void
       success: true,
       data: rows,
       meta: {
-        sport: sport.key, total, count: rows.length,
+        sport: sport.key, label: sport.label, scope: 'week',
+        total, count: rows.length,
         limit: params.limit, offset: params.offset, sort, direction: dir,
         sortable_fields: sport.sortableStatFields,
+        groups: catalog
+          ? catalog.groups.map((gr) => ({
+              key: gr.key,
+              label: gr.label,
+              count: catalog.columns.filter((c) => c.group === gr.key).length,
+            }))
+          : [],
+        columns: projection.map((c) => ({
+          key: c.key,
+          label: c.label,
+          group: c.group,
+          format: c.format,
+          higher_is_better: c.higherIsBetter ?? null,
+          opponent: c.opponent ?? false,
+        })),
+        season_endpoint: sport.teamSeasonTable
+          ? `/api/football/${sport.key}/stats/teams/season`
+          : null,
       },
     });
   } catch (error: any) {
@@ -347,7 +391,7 @@ export async function getLeaders(req: Request, res: Response): Promise<void> {
       meta: { sport: sport.key, season, count: rows.length, categories },
     });
   } catch (error: any) {
-    if (/not found|does not exist/i.test(error?.message || '')) {
+    if (isMissingTable(error)) {
       res.json({
         success: true,
         data: [],
@@ -455,7 +499,7 @@ export async function searchPlayers(req: Request, res: Response): Promise<void> 
       },
     });
   } catch (error: any) {
-    if (/not found|does not exist/i.test(error?.message || '')) {
+    if (isMissingTable(error)) {
       res.json({
         success: true,
         data: [],
@@ -589,7 +633,7 @@ export async function getDiagnostics(req: Request, res: Response): Promise<void>
       },
     });
   } catch (error: any) {
-    if (/not found|does not exist/i.test(error?.message || '')) {
+    if (isMissingTable(error)) {
       res.json({
         success: true,
         diagnostics: [],

--- a/src/controllers/pickem.controller.ts
+++ b/src/controllers/pickem.controller.ts
@@ -106,6 +106,14 @@ export async function getWeekGames(req: Request, res: Response): Promise<void> {
           home_team, away_team, home_display, away_display,
           home_conference, away_conference, neutral_site,
           spread_line, total_line, home_score, away_score, completed,
+          -- Per-side context, attached at ingest. Enough to make a pick without
+          -- leaving the sheet, which is the whole reason it is here.
+          home_rank, away_rank, home_rating, away_rating,
+          home_record, away_record, home_record_season, away_record_season,
+          home_ap_rank, away_ap_rank, home_coaches_rank, away_coaches_rank,
+          home_fpi, away_fpi, home_fpi_rank, away_fpi_rank,
+          home_streak, away_streak,
+          model_home_win_prob, model_pick, model_confidence,
           -- The lock, decided by the server clock against this game's own kickoff.
           -- A game with no posted kickoff is treated as open until it completes,
           -- rather than locked forever by a null.

--- a/src/controllers/pickem.controller.ts
+++ b/src/controllers/pickem.controller.ts
@@ -24,6 +24,7 @@ import { BigQuery } from '@google-cloud/bigquery';
 import { logger } from '../utils/logger';
 import { normalizeBigQueryTemporalValue } from '../utils/bq-normalize';
 import { isMissingTable } from '../utils/football-request';
+import { googleClientId } from '../middleware/auth.middleware';
 
 const PROJECT = process.env.GCP_PROJECT_ID || 'hankstank';
 const DATASET = process.env.PICKEM_DATASET || 'pickem';
@@ -554,13 +555,20 @@ export async function getMyPicks(req: Request, res: Response): Promise<void> {
   }
 }
 
-/** GET /api/pickem/config — what the browser needs to render a sign-in button. */
-export function getConfig(_req: Request, res: Response): void {
+/**
+ * GET /api/pickem/config — what the browser needs to render a sign-in button.
+ *
+ * The client ID is served from here rather than baked into the bundle so the browser
+ * and the server that verifies the token can never disagree about which app is asking,
+ * and so enabling sign-in needs no frontend rebuild.
+ */
+export async function getConfig(_req: Request, res: Response): Promise<void> {
+  const clientId = await googleClientId();
   res.json({
     success: true,
     data: {
-      google_client_id: process.env.GOOGLE_CLIENT_ID || null,
-      auth_configured: Boolean(process.env.GOOGLE_CLIENT_ID),
+      google_client_id: clientId,
+      auth_configured: Boolean(clientId),
       season: currentSeason(),
       sports: ['nfl', 'cfb'],
       pick_types: ['ats', 'su'],

--- a/src/controllers/pickem.controller.ts
+++ b/src/controllers/pickem.controller.ts
@@ -259,6 +259,7 @@ export async function submitPicks(req: Request, res: Response): Promise<void> {
     }
 
     if (accepted.length) {
+      await adoptImportedPicks(user);
       await upsertUser(user);
       await upsertPicks(accepted);
     }
@@ -281,6 +282,63 @@ export async function submitPicks(req: Request, res: Response): Promise<void> {
       error: { code: 'PICKEM_SUBMIT_ERROR', message: 'Failed to save picks' },
     });
   }
+}
+
+/**
+ * Adopt picks imported before this person had ever signed in.
+ *
+ * The contest ran in a spreadsheet first, so those picks predate any Google account and
+ * there was no subject claim to key them on. They were imported against a provisional
+ * id of "email:<address>", and this claims them the first time that person signs in.
+ *
+ * Matching on the email is safe precisely because the token was verified: an ID token
+ * with an unverified email is rejected before it reaches here, so the address is one
+ * Google confirmed the holder controls. Matching on an unverified email would let anyone
+ * claim someone else's history by asserting their address.
+ *
+ * A pick the real account already holds wins over the imported one — the newer,
+ * deliberate pick beats the migrated one — and the provisional rows are then removed so
+ * this is a one-time transfer rather than something that runs forever.
+ */
+async function adoptImportedPicks(user: any): Promise<number> {
+  if (!user.email) return 0;
+  const provisional = `email:${String(user.email).toLowerCase()}`;
+
+  const [existing] = await bigquery.query({
+    query: `SELECT COUNT(*) AS n FROM ${T('picks')} WHERE user_id = @provisional`,
+    params: { provisional },
+  });
+  const pending = Number(existing[0]?.n ?? 0);
+  if (!pending) return 0;
+
+  // pick_id embeds the user, so taking ownership has to rewrite both. Rows the real
+  // account has already picked are left behind and dropped below.
+  await bigquery.query({
+    query: `
+      UPDATE ${T('picks')}
+      SET user_id = @userId,
+          pick_id = CONCAT(@userId, '|', game_id, '|', pick_type),
+          updated_at = CURRENT_TIMESTAMP()
+      WHERE user_id = @provisional
+        AND CONCAT(@userId, '|', game_id, '|', pick_type) NOT IN (
+          SELECT pick_id FROM ${T('picks')} WHERE user_id = @userId
+        )`,
+    params: { userId: user.userId, provisional },
+  });
+
+  await bigquery.query({
+    query: `DELETE FROM ${T('picks')} WHERE user_id = @provisional`,
+    params: { provisional },
+  });
+  await bigquery.query({
+    query: `DELETE FROM ${T('users')} WHERE user_id = @provisional`,
+    params: { provisional },
+  });
+
+  logger.info('adopted imported picks', {
+    userId: user.userId, provisional, pending,
+  });
+  return pending;
 }
 
 /** Record who the leaderboard is naming. Upsert so a renamed account updates. */
@@ -435,6 +493,13 @@ export async function getLeaderboard(req: Request, res: Response): Promise<void>
  */
 export async function getMyPicks(req: Request, res: Response): Promise<void> {
   const user = req.user!;
+  // Also here, not only on submit: someone whose history was imported should see it the
+  // first time they look, without having to make a new pick to trigger the transfer.
+  try {
+    await adoptImportedPicks(user);
+  } catch (error: any) {
+    logger.warn('adoption check failed', { userId: user.userId, error: error.message });
+  }
   const sport = String(req.query.sport || '').toLowerCase();
   const season = parseInt(String(req.query.season || ''), 10) || currentSeason();
   const week = parseInt(String(req.query.week || ''), 10);

--- a/src/controllers/pickem.controller.ts
+++ b/src/controllers/pickem.controller.ts
@@ -40,6 +40,16 @@ const MAX_PICKS_PER_REQUEST = 100;
 
 const T = (name: string) => `\`${PROJECT}.${DATASET}.${name}\``;
 
+/**
+ * Users whose imported-pick adoption has already been settled on this instance.
+ *
+ * Adoption is a one-time transfer, but it has to be attempted on the pick sheet too,
+ * which is the most-requested endpoint. Remembering who has been checked keeps that to
+ * one query per user per instance instead of one per request. In-process and per
+ * instance, which is fine: the worst case is a second harmless check elsewhere.
+ */
+const adoptionChecked = new Set<string>();
+
 function currentSeason(): number {
   const env = parseInt(process.env.CURRENT_SEASON || '', 10);
   return Number.isFinite(env) ? env : new Date().getFullYear();
@@ -117,6 +127,16 @@ export async function getWeekGames(req: Request, res: Response): Promise<void> {
 
     let picks: any[] = [];
     if (req.user) {
+      // Before reading their picks, so a first-time signer-in sees an imported history
+      // on the sheet itself rather than only after visiting another page.
+      try {
+        await adoptImportedPicks(req.user);
+      } catch (error: any) {
+        logger.warn('adoption check failed', {
+          userId: req.user.userId, error: error.message,
+        });
+      }
+
       const [rows] = await bigquery.query({
         query: `SELECT game_id, pick_type, selected, spread_at_pick, updated_at
                 FROM ${T('picks')}
@@ -303,6 +323,12 @@ export async function submitPicks(req: Request, res: Response): Promise<void> {
  */
 async function adoptImportedPicks(user: any): Promise<number> {
   if (!user.email) return 0;
+  // Checked once per user per instance. Adoption has to run on the sheet as well as on
+  // /me — otherwise signing in and going straight to the pick sheet shows nothing until
+  // some other request happens to trigger it — and the sheet is the hot path, so the
+  // check must not cost a query every time.
+  if (adoptionChecked.has(user.userId)) return 0;
+
   const provisional = `email:${String(user.email).toLowerCase()}`;
 
   const [existing] = await bigquery.query({
@@ -310,7 +336,10 @@ async function adoptImportedPicks(user: any): Promise<number> {
     params: { provisional },
   });
   const pending = Number(existing[0]?.n ?? 0);
-  if (!pending) return 0;
+  if (!pending) {
+    adoptionChecked.add(user.userId);
+    return 0;
+  }
 
   // pick_id embeds the user, so taking ownership has to rewrite both. Rows the real
   // account has already picked are left behind and dropped below.
@@ -336,6 +365,7 @@ async function adoptImportedPicks(user: any): Promise<number> {
     params: { provisional },
   });
 
+  adoptionChecked.add(user.userId);
   logger.info('adopted imported picks', {
     userId: user.userId, provisional, pending,
   });
@@ -574,4 +604,9 @@ export async function getConfig(_req: Request, res: Response): Promise<void> {
       pick_types: ['ats', 'su'],
     },
   });
+}
+
+/** Test seam: the adoption memo is per-instance and must not leak between tests. */
+export function __resetAdoptionMemo(): void {
+  adoptionChecked.clear();
 }

--- a/src/controllers/pickem.controller.ts
+++ b/src/controllers/pickem.controller.ts
@@ -1,0 +1,504 @@
+/**
+ * The pick'em contest: pick sheet, submissions, and the public leaderboard.
+ *
+ * Two rules are enforced here and nowhere else, because a client cannot be trusted with
+ * either:
+ *
+ *   The kickoff lock. A pick is editable until its own game starts — per game, not per
+ *   week, so a Thursday game locks while Sunday's are still open. The cutoff is read
+ *   from pickem.games at write time and compared against the server clock; a client
+ *   clock is not evidence.
+ *
+ *   The side, not the team. A pick stores 'home' or 'away'. The two sports disagree
+ *   about how a team is spelled, and the same feed disagrees with itself, so a stored
+ *   team name is a pick that can be orphaned by a rename. The UI shows names; the
+ *   record keeps sides.
+ *
+ * Grading lives in BigQuery views (pickem.graded_picks and the two leaderboards), so
+ * this file never scores anything — a result landing in pickem.games grades the picks
+ * that depend on it immediately, with nothing scheduled that can fall behind.
+ */
+
+import { Request, Response } from 'express';
+import { BigQuery } from '@google-cloud/bigquery';
+import { logger } from '../utils/logger';
+import { normalizeBigQueryTemporalValue } from '../utils/bq-normalize';
+import { isMissingTable } from '../utils/football-request';
+
+const PROJECT = process.env.GCP_PROJECT_ID || 'hankstank';
+const DATASET = process.env.PICKEM_DATASET || 'pickem';
+const bigquery = new BigQuery({ projectId: PROJECT });
+
+const SPORTS = new Set(['nfl', 'cfb']);
+const PICK_TYPES = new Set(['ats', 'su']);
+const SIDES = new Set(['home', 'away']);
+
+/** A week's sheet is capped: the college slate runs to hundreds of games. */
+const MAX_GAMES = 400;
+const MAX_PICKS_PER_REQUEST = 100;
+
+const T = (name: string) => `\`${PROJECT}.${DATASET}.${name}\``;
+
+function currentSeason(): number {
+  const env = parseInt(process.env.CURRENT_SEASON || '', 10);
+  return Number.isFinite(env) ? env : new Date().getFullYear();
+}
+
+function badRequest(res: Response, code: string, message: string): void {
+  res.status(400).json({ success: false, error: { code, message } });
+}
+
+function normalizeGame(row: any): any {
+  return {
+    ...row,
+    kickoff: normalizeBigQueryTemporalValue(row.kickoff),
+    created_at: normalizeBigQueryTemporalValue(row.created_at),
+    updated_at: normalizeBigQueryTemporalValue(row.updated_at),
+  };
+}
+
+/**
+ * GET /api/pickem/games?sport=&season=&week=
+ *
+ * The week's sheet. Every game carries `locked`, computed server-side, so the UI never
+ * has to decide from a client clock whether a game is still open.
+ *
+ * Anonymous callers get the sheet without picks; a signed-in caller gets their own picks
+ * merged in, which is what makes this one request rather than two.
+ */
+export async function getWeekGames(req: Request, res: Response): Promise<void> {
+  const sport = String(req.query.sport || 'nfl').toLowerCase();
+  if (!SPORTS.has(sport)) {
+    return badRequest(res, 'UNKNOWN_SPORT', `sport must be one of: nfl, cfb`);
+  }
+
+  const season = parseInt(String(req.query.season || ''), 10) || currentSeason();
+  const weekRaw = req.query.week;
+
+  try {
+    // No week given: the earliest week that still has an unplayed game, which is the
+    // one a visitor almost always wants.
+    let week = parseInt(String(weekRaw || ''), 10);
+    if (!Number.isFinite(week)) {
+      const [rows] = await bigquery.query({
+        query: `SELECT MIN(week) AS week FROM ${T('games')}
+                WHERE sport = @sport AND season = @season AND NOT completed`,
+        params: { sport, season },
+      });
+      week = rows[0]?.week ?? 1;
+    }
+
+    const [games] = await bigquery.query({
+      query: `
+        SELECT
+          game_id, sport, division, season, week, kickoff, start_time_tbd,
+          home_team, away_team, home_display, away_display,
+          home_conference, away_conference, neutral_site,
+          spread_line, total_line, home_score, away_score, completed,
+          -- The lock, decided by the server clock against this game's own kickoff.
+          -- A game with no posted kickoff is treated as open until it completes,
+          -- rather than locked forever by a null.
+          (completed OR (kickoff IS NOT NULL AND kickoff <= CURRENT_TIMESTAMP()))
+            AS locked
+        FROM ${T('games')}
+        WHERE sport = @sport AND season = @season AND week = @week
+        ORDER BY kickoff NULLS LAST, home_display
+        LIMIT ${MAX_GAMES}`,
+      params: { sport, season, week },
+    });
+
+    // Weeks that exist at all, so the UI can build its week bar without guessing.
+    const [weeks] = await bigquery.query({
+      query: `SELECT DISTINCT week FROM ${T('games')}
+              WHERE sport = @sport AND season = @season ORDER BY week`,
+      params: { sport, season },
+    });
+
+    let picks: any[] = [];
+    if (req.user) {
+      const [rows] = await bigquery.query({
+        query: `SELECT game_id, pick_type, selected, spread_at_pick, updated_at
+                FROM ${T('picks')}
+                WHERE user_id = @userId AND sport = @sport
+                  AND season = @season AND week = @week`,
+        params: { userId: req.user.userId, sport, season, week },
+      });
+      picks = rows.map((r: any) => ({
+        ...r, updated_at: normalizeBigQueryTemporalValue(r.updated_at),
+      }));
+    }
+
+    res.json({
+      success: true,
+      data: games.map(normalizeGame),
+      meta: {
+        sport,
+        season,
+        week,
+        weeks: weeks.map((w: any) => w.week),
+        count: games.length,
+        open: games.filter((g: any) => !g.locked).length,
+        signed_in: Boolean(req.user),
+        picks,
+        // Stated rather than implied: a sheet where most games have no line still
+        // supports straight-up picks, and the UI should say so.
+        with_spread: games.filter((g: any) => g.spread_line !== null).length,
+      },
+    });
+  } catch (error: any) {
+    if (isMissingTable(error)) {
+      res.json({
+        success: true,
+        data: [],
+        meta: { sport, season, note: 'The contest tables are not built yet.' },
+      });
+      return;
+    }
+    logger.error('pickem games failed', { sport, season, error: error.message });
+    res.status(500).json({
+      success: false,
+      error: { code: 'PICKEM_GAMES_ERROR', message: 'Failed to load the week' },
+    });
+  }
+}
+
+/**
+ * PUT /api/pickem/picks
+ *
+ * Body: { sport, season, week, picks: [{ game_id, pick_type, selected }] }
+ *
+ * Upsert, not append: pick_id is derived from (user, game, type), so re-submitting a
+ * game replaces that pick rather than adding a second one. Locked games are rejected
+ * individually and reported back — a sheet where one game has kicked off should still
+ * save the other nine rather than failing wholesale.
+ */
+export async function submitPicks(req: Request, res: Response): Promise<void> {
+  const user = req.user!;
+  const { sport, season, week, picks } = req.body || {};
+
+  const sportKey = String(sport || '').toLowerCase();
+  if (!SPORTS.has(sportKey)) {
+    return badRequest(res, 'UNKNOWN_SPORT', 'sport must be one of: nfl, cfb');
+  }
+  const seasonNum = parseInt(String(season), 10);
+  const weekNum = parseInt(String(week), 10);
+  if (!Number.isFinite(seasonNum) || !Number.isFinite(weekNum)) {
+    return badRequest(res, 'BAD_WEEK', 'season and week are required');
+  }
+  if (!Array.isArray(picks) || !picks.length) {
+    return badRequest(res, 'NO_PICKS', 'picks must be a non-empty array');
+  }
+  if (picks.length > MAX_PICKS_PER_REQUEST) {
+    return badRequest(res, 'TOO_MANY_PICKS',
+      `at most ${MAX_PICKS_PER_REQUEST} picks per request`);
+  }
+
+  // Shape-check everything before touching BigQuery, so a malformed body costs nothing.
+  const cleaned: Array<{ gameId: string; pickType: string; selected: string }> = [];
+  for (const p of picks) {
+    const gameId = String(p?.game_id ?? '').trim();
+    const pickType = String(p?.pick_type ?? '').toLowerCase();
+    const selected = String(p?.selected ?? '').toLowerCase();
+    if (!gameId || !PICK_TYPES.has(pickType) || !SIDES.has(selected)) {
+      return badRequest(res, 'BAD_PICK',
+        'each pick needs game_id, pick_type (ats|su) and selected (home|away)');
+    }
+    cleaned.push({ gameId, pickType, selected });
+  }
+
+  try {
+    // The authoritative state of every game being picked: does it exist in this week,
+    // has it kicked off, and what is the line right now. Trusting the body for any of
+    // this would let a caller pick a game that has finished.
+    const [gameRows] = await bigquery.query({
+      query: `
+        SELECT game_id, spread_line,
+               (completed OR (kickoff IS NOT NULL AND kickoff <= CURRENT_TIMESTAMP()))
+                 AS locked
+        FROM ${T('games')}
+        WHERE sport = @sport AND season = @season AND week = @week
+          AND game_id IN UNNEST(@ids)`,
+      params: {
+        sport: sportKey, season: seasonNum, week: weekNum,
+        ids: cleaned.map((c) => c.gameId),
+      },
+    });
+
+    const byId = new Map(gameRows.map((g: any) => [String(g.game_id), g]));
+    const accepted: any[] = [];
+    const rejected: Array<{ game_id: string; reason: string }> = [];
+
+    for (const c of cleaned) {
+      const game = byId.get(c.gameId);
+      if (!game) {
+        rejected.push({ game_id: c.gameId, reason: 'not in this week' });
+        continue;
+      }
+      if (game.locked) {
+        rejected.push({ game_id: c.gameId, reason: 'kicked off' });
+        continue;
+      }
+      if (c.pickType === 'ats' && game.spread_line === null) {
+        // An ATS pick with no line has nothing to grade against.
+        rejected.push({ game_id: c.gameId, reason: 'no spread posted' });
+        continue;
+      }
+      accepted.push({
+        pick_id: `${user.userId}|${c.gameId}|${c.pickType}`,
+        user_id: user.userId,
+        sport: sportKey,
+        season: seasonNum,
+        week: weekNum,
+        game_id: c.gameId,
+        pick_type: c.pickType,
+        selected: c.selected,
+        // The line as it stands now, which is what the user was shown. ATS grades
+        // against this rather than the close, so a later move cannot lose their pick.
+        spread_at_pick: game.spread_line,
+      });
+    }
+
+    if (accepted.length) {
+      await upsertUser(user);
+      await upsertPicks(accepted);
+    }
+
+    res.json({
+      success: true,
+      data: { accepted: accepted.length, rejected },
+      meta: {
+        sport: sportKey, season: seasonNum, week: weekNum,
+        // Partial success is the normal case mid-week, not an error.
+        note: rejected.length
+          ? `${accepted.length} saved, ${rejected.length} rejected.`
+          : `${accepted.length} saved.`,
+      },
+    });
+  } catch (error: any) {
+    logger.error('pickem submit failed', { user: user.userId, error: error.message });
+    res.status(500).json({
+      success: false,
+      error: { code: 'PICKEM_SUBMIT_ERROR', message: 'Failed to save picks' },
+    });
+  }
+}
+
+/** Record who the leaderboard is naming. Upsert so a renamed account updates. */
+async function upsertUser(user: any): Promise<void> {
+  await bigquery.query({
+    query: `
+      MERGE ${T('users')} AS t
+      USING (SELECT @userId AS user_id, @email AS email,
+                    @displayName AS display_name, @pictureUrl AS picture_url) AS s
+      ON t.user_id = s.user_id
+      WHEN MATCHED THEN UPDATE SET
+        email = s.email, display_name = s.display_name,
+        picture_url = s.picture_url, last_seen_at = CURRENT_TIMESTAMP()
+      WHEN NOT MATCHED THEN INSERT
+        (user_id, email, display_name, picture_url, created_at, last_seen_at)
+        VALUES (s.user_id, s.email, s.display_name, s.picture_url,
+                CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP())`,
+    params: {
+      userId: user.userId,
+      email: user.email,
+      displayName: user.displayName,
+      pictureUrl: user.pictureUrl,
+    },
+  });
+}
+
+/**
+ * Upsert a batch of picks in one statement.
+ *
+ * One MERGE rather than a statement per pick: BigQuery meters DML per table per day,
+ * and a ten-game sheet saved a few times over a week would otherwise be a hundred
+ * statements instead of a handful.
+ */
+async function upsertPicks(rows: any[]): Promise<void> {
+  const values = rows.map((_, i) => `(
+      @pickId${i}, @userId${i}, @sport${i}, @season${i}, @week${i},
+      @gameId${i}, @pickType${i}, @selected${i}, @spread${i}
+    )`).join(', ');
+
+  const params: Record<string, any> = {};
+  const types: Record<string, any> = {};
+  rows.forEach((r, i) => {
+    params[`pickId${i}`] = r.pick_id;
+    params[`userId${i}`] = r.user_id;
+    params[`sport${i}`] = r.sport;
+    params[`season${i}`] = r.season;
+    params[`week${i}`] = r.week;
+    params[`gameId${i}`] = r.game_id;
+    params[`pickType${i}`] = r.pick_type;
+    params[`selected${i}`] = r.selected;
+    params[`spread${i}`] = r.spread_at_pick;
+    // Declared because a null spread is otherwise an untyped parameter BigQuery rejects.
+    types[`spread${i}`] = 'FLOAT64';
+  });
+
+  await bigquery.query({
+    query: `
+      MERGE ${T('picks')} AS t
+      USING (
+        SELECT * FROM UNNEST([
+          STRUCT<pick_id STRING, user_id STRING, sport STRING, season INT64,
+                 week INT64, game_id STRING, pick_type STRING, selected STRING,
+                 spread_at_pick FLOAT64>
+          ${values}
+        ])
+      ) AS s
+      ON t.pick_id = s.pick_id
+      WHEN MATCHED THEN UPDATE SET
+        selected = s.selected,
+        spread_at_pick = s.spread_at_pick,
+        updated_at = CURRENT_TIMESTAMP()
+      WHEN NOT MATCHED THEN INSERT
+        (pick_id, user_id, sport, season, week, game_id, pick_type, selected,
+         spread_at_pick, created_at, updated_at)
+        VALUES (s.pick_id, s.user_id, s.sport, s.season, s.week, s.game_id,
+                s.pick_type, s.selected, s.spread_at_pick,
+                CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP())`,
+    params,
+    types,
+  });
+}
+
+/**
+ * GET /api/pickem/leaderboard?sport=&season=&week=&pick_type=
+ *
+ * Public. Omit `week` for season standings.
+ *
+ * Every row carries the market's record on that user's own games, which is the only
+ * honest comparison — someone who picked six games is not comparable to the market
+ * across sixty.
+ */
+export async function getLeaderboard(req: Request, res: Response): Promise<void> {
+  const sport = String(req.query.sport || 'nfl').toLowerCase();
+  if (!SPORTS.has(sport)) {
+    return badRequest(res, 'UNKNOWN_SPORT', 'sport must be one of: nfl, cfb');
+  }
+  const pickType = String(req.query.pick_type || 'ats').toLowerCase();
+  if (!PICK_TYPES.has(pickType)) {
+    return badRequest(res, 'BAD_PICK_TYPE', 'pick_type must be ats or su');
+  }
+  const season = parseInt(String(req.query.season || ''), 10) || currentSeason();
+  const week = parseInt(String(req.query.week || ''), 10);
+  const weekly = Number.isFinite(week);
+
+  try {
+    const [rows] = await bigquery.query({
+      query: weekly
+        ? `SELECT * FROM ${T('leaderboard_weekly')}
+           WHERE season=@season AND sport=@sport AND pick_type=@pickType AND week=@week
+           ORDER BY wins DESC, win_pct DESC, picks_graded DESC LIMIT 200`
+        : `SELECT * FROM ${T('leaderboard_season')}
+           WHERE season=@season AND sport=@sport AND pick_type=@pickType
+           ORDER BY wins DESC, win_pct DESC, picks_graded DESC LIMIT 200`,
+      params: weekly
+        ? { season, sport, pickType, week }
+        : { season, sport, pickType },
+    });
+
+    res.json({
+      success: true,
+      data: rows.map((r: any, i: number) => ({ rank: i + 1, ...r })),
+      meta: {
+        sport, season, pick_type: pickType,
+        week: weekly ? week : null,
+        scope: weekly ? 'week' : 'season',
+        count: rows.length,
+        you: req.user?.userId ?? null,
+      },
+    });
+  } catch (error: any) {
+    if (isMissingTable(error)) {
+      res.json({
+        success: true,
+        data: [],
+        meta: { sport, season, note: 'No picks have been made yet.' },
+      });
+      return;
+    }
+    logger.error('pickem leaderboard failed', { sport, error: error.message });
+    res.status(500).json({
+      success: false,
+      error: { code: 'PICKEM_LEADERBOARD_ERROR', message: 'Failed to load the leaderboard' },
+    });
+  }
+}
+
+/**
+ * GET /api/pickem/me?sport=&season=&week=
+ *
+ * The signed-in user's own graded picks, which the leaderboard cannot show: it
+ * aggregates, and someone reviewing their week wants the individual results.
+ */
+export async function getMyPicks(req: Request, res: Response): Promise<void> {
+  const user = req.user!;
+  const sport = String(req.query.sport || '').toLowerCase();
+  const season = parseInt(String(req.query.season || ''), 10) || currentSeason();
+  const week = parseInt(String(req.query.week || ''), 10);
+
+  const filters = ['user_id = @userId', 'season = @season'];
+  const params: Record<string, any> = { userId: user.userId, season };
+  if (SPORTS.has(sport)) { filters.push('sport = @sport'); params.sport = sport; }
+  if (Number.isFinite(week)) { filters.push('week = @week'); params.week = week; }
+
+  try {
+    const [rows] = await bigquery.query({
+      query: `
+        SELECT sport, season, week, game_id, pick_type, selected,
+               graded_spread, closing_spread, margin, home_display, away_display,
+               home_score, away_score, completed, kickoff,
+               winning_side, covering_side, is_correct, is_push,
+               vegas_side, vegas_correct, took_underdog, updated_at
+        FROM ${T('graded_picks')}
+        WHERE ${filters.join(' AND ')}
+        ORDER BY week DESC, kickoff
+        LIMIT 500`,
+      params,
+    });
+
+    const graded = rows.filter((r: any) => r.is_correct !== null);
+    res.json({
+      success: true,
+      data: rows.map(normalizeGame),
+      meta: {
+        season,
+        sport: SPORTS.has(sport) ? sport : null,
+        week: Number.isFinite(week) ? week : null,
+        count: rows.length,
+        record: {
+          wins: graded.filter((r: any) => r.is_correct === true).length,
+          losses: graded.filter((r: any) => r.is_correct === false).length,
+          pushes: rows.filter((r: any) => r.is_push).length,
+          pending: rows.length - graded.length - rows.filter((r: any) => r.is_push).length,
+        },
+      },
+    });
+  } catch (error: any) {
+    if (isMissingTable(error)) {
+      res.json({ success: true, data: [], meta: { note: 'No picks yet.' } });
+      return;
+    }
+    logger.error('pickem me failed', { user: user.userId, error: error.message });
+    res.status(500).json({
+      success: false,
+      error: { code: 'PICKEM_ME_ERROR', message: 'Failed to load your picks' },
+    });
+  }
+}
+
+/** GET /api/pickem/config — what the browser needs to render a sign-in button. */
+export function getConfig(_req: Request, res: Response): void {
+  res.json({
+    success: true,
+    data: {
+      google_client_id: process.env.GOOGLE_CLIENT_ID || null,
+      auth_configured: Boolean(process.env.GOOGLE_CLIENT_ID),
+      season: currentSeason(),
+      sports: ['nfl', 'cfb'],
+      pick_types: ['ats', 'su'],
+    },
+  });
+}

--- a/src/controllers/rankings.controller.ts
+++ b/src/controllers/rankings.controller.ts
@@ -9,6 +9,7 @@
 import { Request, Response } from 'express';
 import { BigQuery } from '@google-cloud/bigquery';
 import { logger } from '../utils/logger';
+import { isMissingTable } from '../utils/football-request';
 import { getRankingSport, RankingSportConfig } from '../config/rankings.config';
 
 const PROJECT = process.env.GCP_PROJECT_ID || 'hankstank';
@@ -100,7 +101,7 @@ export async function getRankings(req: Request, res: Response): Promise<void> {
       },
     });
   } catch (error: any) {
-    const missingTable = /not found|does not exist/i.test(error?.message || '');
+    const missingTable = isMissingTable(error);
     if (missingTable) {
       logger.warn('power rankings table missing', { sport: sport.key, table });
       res.json({

--- a/src/middleware/auth.middleware.ts
+++ b/src/middleware/auth.middleware.ts
@@ -52,6 +52,17 @@ const SECRET_PROJECT = process.env.GCP_PROJECT_ID || 'hankstank';
 
 let clientId: string | null | undefined;
 let clientIdLoad: Promise<string | null> | null = null;
+let clientIdRetryAfter = 0;
+
+/**
+ * How long to wait before re-reading a MISSING client id.
+ *
+ * A found id is cached for the life of the instance — it does not change. A missing one
+ * must not be, and that distinction matters twice over: turning sign-in on would
+ * otherwise require new instances rather than just storing the id, and a transient
+ * Secret Manager failure at cold start would disable sign-in on that instance forever.
+ */
+const MISSING_RETRY_MS = 60_000;
 
 async function loadClientId(): Promise<string | null> {
   const fromEnv = (process.env.GOOGLE_CLIENT_ID || '').trim();
@@ -75,13 +86,34 @@ async function loadClientId(): Promise<string | null> {
   }
 }
 
-/** Resolve once per instance. */
+/**
+ * The client id, resolved once when found and retried periodically when not.
+ */
 export async function googleClientId(): Promise<string | null> {
-  if (clientId === undefined) {
-    clientIdLoad = clientIdLoad || loadClientId();
-    clientId = await clientIdLoad;
+  if (clientId) return clientId;
+
+  if (clientId === null && Date.now() < clientIdRetryAfter) return null;
+
+  if (!clientIdLoad) {
+    clientIdLoad = loadClientId().then((value) => {
+      clientId = value;
+      // Only a miss gets an expiry; a hit is final for this instance.
+      clientIdRetryAfter = value ? 0 : Date.now() + MISSING_RETRY_MS;
+      clientIdLoad = null;
+      return value;
+    }).catch((error) => {
+      clientId = null;
+      clientIdRetryAfter = Date.now() + MISSING_RETRY_MS;
+      clientIdLoad = null;
+      throw error;
+    });
   }
-  return clientId;
+
+  try {
+    return await clientIdLoad;
+  } catch {
+    return null;
+  }
 }
 
 export async function isAuthConfigured(): Promise<boolean> {
@@ -92,6 +124,7 @@ export async function isAuthConfigured(): Promise<boolean> {
 export function __resetClientId(): void {
   clientId = undefined;
   clientIdLoad = null;
+  clientIdRetryAfter = 0;
 }
 
 const client = new OAuth2Client();

--- a/src/middleware/auth.middleware.ts
+++ b/src/middleware/auth.middleware.ts
@@ -38,13 +38,60 @@ declare global {
 }
 
 /**
- * The web OAuth client ID. Both the audience this accepts and the ID the browser signs
- * in with, so they cannot drift apart.
+ * The web OAuth client ID: both the audience this verifies against and the ID the
+ * browser signs in with, so the two cannot drift apart.
+ *
+ * Resolved from the environment first, then from Secret Manager. The second path exists
+ * so adding sign-in needs no code change and no redeploy — create the OAuth client in
+ * the console, store the id, and the next instance picks it up. It is not a secret (it
+ * identifies the app, not a user, and the browser must have it), but Secret Manager is
+ * the one config store this project already reads at runtime.
  */
-export const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID || '';
+const CLIENT_ID_SECRET = process.env.GOOGLE_CLIENT_ID_SECRET || 'google-oauth-client-id';
+const SECRET_PROJECT = process.env.GCP_PROJECT_ID || 'hankstank';
 
-export function isAuthConfigured(): boolean {
-  return Boolean(GOOGLE_CLIENT_ID);
+let clientId: string | null | undefined;
+let clientIdLoad: Promise<string | null> | null = null;
+
+async function loadClientId(): Promise<string | null> {
+  const fromEnv = (process.env.GOOGLE_CLIENT_ID || '').trim();
+  if (fromEnv) return fromEnv;
+
+  try {
+    const { SecretManagerServiceClient } =
+      await import('@google-cloud/secret-manager');
+    const sm = new SecretManagerServiceClient();
+    const [version] = await sm.accessSecretVersion({
+      name: `projects/${SECRET_PROJECT}/secrets/${CLIENT_ID_SECRET}/versions/latest`,
+    });
+    const value = version.payload?.data?.toString().trim() || null;
+    if (value) logger.info('Google client ID loaded from Secret Manager');
+    return value;
+  } catch (error: any) {
+    // Expected until sign-in is set up. Every read endpoint still works; the writes
+    // answer AUTH_NOT_CONFIGURED, which says whose problem it is.
+    logger.info('no Google client ID configured', { error: error?.message?.slice(0, 120) });
+    return null;
+  }
+}
+
+/** Resolve once per instance. */
+export async function googleClientId(): Promise<string | null> {
+  if (clientId === undefined) {
+    clientIdLoad = clientIdLoad || loadClientId();
+    clientId = await clientIdLoad;
+  }
+  return clientId;
+}
+
+export async function isAuthConfigured(): Promise<boolean> {
+  return Boolean(await googleClientId());
+}
+
+/** Test seam. */
+export function __resetClientId(): void {
+  clientId = undefined;
+  clientIdLoad = null;
 }
 
 const client = new OAuth2Client();
@@ -71,7 +118,8 @@ function bearer(req: Request): string | null {
  * whether an anonymous request is an error or merely a reader.
  */
 export async function verifyToken(token: string): Promise<AuthUser | null> {
-  if (!GOOGLE_CLIENT_ID) return null;
+  const audience = await googleClientId();
+  if (!audience) return null;
 
   prune();
   const hit = verified.get(token);
@@ -80,7 +128,7 @@ export async function verifyToken(token: string): Promise<AuthUser | null> {
   try {
     const ticket = await client.verifyIdToken({
       idToken: token,
-      audience: GOOGLE_CLIENT_ID,
+      audience,
     });
     const payload = ticket.getPayload();
     if (!payload?.sub) return null;
@@ -134,7 +182,7 @@ export async function attachUser(
 export async function requireUser(
   req: Request, res: Response, next: NextFunction,
 ): Promise<void> {
-  if (!isAuthConfigured()) {
+  if (!(await isAuthConfigured())) {
     // Distinguished from a bad token on purpose: this is the server's fault, not the
     // caller's, and the message says which so nobody debugs the wrong end.
     res.status(503).json({

--- a/src/middleware/auth.middleware.ts
+++ b/src/middleware/auth.middleware.ts
@@ -1,0 +1,170 @@
+/**
+ * Google sign-in verification.
+ *
+ * The browser signs in with Google Identity Services and gets an ID token — a JWT
+ * Google signed. Every authenticated request carries it as a bearer token and this
+ * verifies the signature, the issuer and the audience against Google's published keys.
+ * There is no session store and no cookie: the token already carries an expiry and an
+ * identity, so re-verifying it is cheaper and safer than minting a second credential to
+ * keep in sync.
+ *
+ * Identity is keyed on the `sub` claim, never the email. A Google account's email can
+ * change; its subject cannot, and keying on email would silently split or merge people's
+ * pick history when it does.
+ *
+ * Verification results are cached briefly. Google's library fetches and caches the
+ * signing certificates itself, but the RSA verify still costs a few milliseconds, and a
+ * pick sheet fires several requests at once.
+ */
+
+import { Request, Response, NextFunction } from 'express';
+import { OAuth2Client } from 'google-auth-library';
+import { logger } from '../utils/logger';
+
+export interface AuthUser {
+  userId: string;       // Google `sub`
+  email: string | null;
+  displayName: string | null;
+  pictureUrl: string | null;
+}
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Express {
+    interface Request {
+      user?: AuthUser;
+    }
+  }
+}
+
+/**
+ * The web OAuth client ID. Both the audience this accepts and the ID the browser signs
+ * in with, so they cannot drift apart.
+ */
+export const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID || '';
+
+export function isAuthConfigured(): boolean {
+  return Boolean(GOOGLE_CLIENT_ID);
+}
+
+const client = new OAuth2Client();
+
+/** Short-lived verification cache, keyed on the token itself. */
+const verified = new Map<string, { user: AuthUser; expires: number }>();
+const CACHE_MS = 5 * 60 * 1000;
+
+function prune(): void {
+  const now = Date.now();
+  for (const [token, entry] of verified) {
+    if (entry.expires <= now) verified.delete(token);
+  }
+}
+
+function bearer(req: Request): string | null {
+  const header = req.headers.authorization || '';
+  const match = /^Bearer\s+(.+)$/i.exec(header);
+  return match ? match[1].trim() : null;
+}
+
+/**
+ * Verify a Google ID token. Returns null rather than throwing, so callers decide
+ * whether an anonymous request is an error or merely a reader.
+ */
+export async function verifyToken(token: string): Promise<AuthUser | null> {
+  if (!GOOGLE_CLIENT_ID) return null;
+
+  prune();
+  const hit = verified.get(token);
+  if (hit && hit.expires > Date.now()) return hit.user;
+
+  try {
+    const ticket = await client.verifyIdToken({
+      idToken: token,
+      audience: GOOGLE_CLIENT_ID,
+    });
+    const payload = ticket.getPayload();
+    if (!payload?.sub) return null;
+
+    // A token for an unverified email is a token for an address the holder may not own.
+    if (payload.email && payload.email_verified === false) {
+      logger.warn('rejected a token with an unverified email');
+      return null;
+    }
+
+    const user: AuthUser = {
+      userId: payload.sub,
+      email: payload.email ?? null,
+      displayName: payload.name ?? payload.given_name ?? null,
+      pictureUrl: payload.picture ?? null,
+    };
+
+    // Never cached past the token's own expiry.
+    const tokenExpiry = (payload.exp ?? 0) * 1000;
+    verified.set(token, {
+      user,
+      expires: Math.min(Date.now() + CACHE_MS, tokenExpiry || Date.now() + CACHE_MS),
+    });
+    return user;
+  } catch (error: any) {
+    // Expected constantly: expired tokens, tokens for another audience. Logged at debug
+    // so a real misconfiguration is not buried in routine noise.
+    logger.debug('ID token verification failed', { error: error?.message });
+    return null;
+  }
+}
+
+/**
+ * Attach `req.user` when a valid token is present, and continue either way.
+ *
+ * For the endpoints anyone may read — the pick sheet, the public leaderboard — where
+ * being signed in changes what is shown but is not required to see anything.
+ */
+export async function attachUser(
+  req: Request, _res: Response, next: NextFunction,
+): Promise<void> {
+  const token = bearer(req);
+  if (token) {
+    const user = await verifyToken(token);
+    if (user) req.user = user;
+  }
+  next();
+}
+
+/** Require a signed-in user, or 401. */
+export async function requireUser(
+  req: Request, res: Response, next: NextFunction,
+): Promise<void> {
+  if (!isAuthConfigured()) {
+    // Distinguished from a bad token on purpose: this is the server's fault, not the
+    // caller's, and the message says which so nobody debugs the wrong end.
+    res.status(503).json({
+      success: false,
+      error: {
+        code: 'AUTH_NOT_CONFIGURED',
+        message: 'Sign-in is not configured on this server.',
+      },
+    });
+    return;
+  }
+
+  const token = bearer(req);
+  const user = token ? await verifyToken(token) : null;
+  if (!user) {
+    res.status(401).json({
+      success: false,
+      error: {
+        code: 'SIGN_IN_REQUIRED',
+        message: 'Sign in with Google to make picks.',
+      },
+    });
+    return;
+  }
+
+  req.user = user;
+  next();
+}
+
+/** Test seam. */
+export function __clearVerificationCache(): void {
+  verified.clear();
+}

--- a/src/routes/football.routes.ts
+++ b/src/routes/football.routes.ts
@@ -18,6 +18,10 @@ import {
 // Rankings share one schema across every sport, so they share one controller; this
 // path stays only so the football tab's existing URL keeps working.
 import { getRankings } from '../controllers/rankings.controller';
+import {
+  searchTeamSeasonStats,
+  getTeams,
+} from '../controllers/football-stats.controller';
 
 const router = Router({ mergeParams: true });
 
@@ -26,9 +30,12 @@ router.get('/:sport/predictions/accuracy', getAccuracy);
 router.get('/:sport/predictions/diagnostics', getDiagnostics);
 router.get('/:sport/predictions', getPredictions);
 router.get('/:sport/rankings', getRankings);
+// season totals before the bare /stats/teams so the more specific path wins
+router.get('/:sport/stats/teams/season', searchTeamSeasonStats);
 router.get('/:sport/stats/teams', searchTeamStats);
 router.get('/:sport/stats/leaders', getLeaders);
 router.get('/:sport/stats/players', searchPlayers);
 router.get('/:sport/stats/games', searchGames);
+router.get('/:sport/teams', getTeams);
 
 export default router;

--- a/src/routes/football.routes.ts
+++ b/src/routes/football.routes.ts
@@ -22,6 +22,11 @@ import {
   searchTeamSeasonStats,
   getTeams,
 } from '../controllers/football-stats.controller';
+import {
+  getScoreboard,
+  getSchedule,
+  getGameDetail,
+} from '../controllers/football-games.controller';
 
 const router = Router({ mergeParams: true });
 
@@ -37,5 +42,11 @@ router.get('/:sport/stats/leaders', getLeaders);
 router.get('/:sport/stats/players', searchPlayers);
 router.get('/:sport/stats/games', searchGames);
 router.get('/:sport/teams', getTeams);
+// Live scoreboard and schedule. Declared before /games/:gameId so neither is captured
+// as a game id, and kept distinct from /stats/games, which serves completed results
+// out of BigQuery rather than the live feed.
+router.get('/:sport/scoreboard', getScoreboard);
+router.get('/:sport/schedule', getSchedule);
+router.get('/:sport/games/:gameId', getGameDetail);
 
 export default router;

--- a/src/routes/pickem.routes.ts
+++ b/src/routes/pickem.routes.ts
@@ -1,0 +1,30 @@
+/**
+ * Pick'em routes: /api/pickem/*
+ *
+ * Reading is public — the sheet and the leaderboard are meant to be shareable with
+ * people who have not signed in. Writing requires a verified Google token.
+ *
+ * `attachUser` runs on the public reads rather than `requireUser` so a signed-in
+ * visitor gets their own picks merged into the sheet in the same request, while an
+ * anonymous one still sees the games.
+ */
+
+import { Router } from 'express';
+import { attachUser, requireUser } from '../middleware/auth.middleware';
+import {
+  getWeekGames,
+  submitPicks,
+  getLeaderboard,
+  getMyPicks,
+  getConfig,
+} from '../controllers/pickem.controller';
+
+const router = Router();
+
+router.get('/config', getConfig);
+router.get('/games', attachUser, getWeekGames);
+router.get('/leaderboard', attachUser, getLeaderboard);
+router.get('/me', requireUser, getMyPicks);
+router.put('/picks', requireUser, submitPicks);
+
+export default router;

--- a/src/services/cfbd.service.ts
+++ b/src/services/cfbd.service.ts
@@ -1,0 +1,172 @@
+/**
+ * CollegeFootballData client — the first LIVE data path in the football stack.
+ *
+ * Everything football has done so far is batch: the ML pipeline writes BigQuery, the
+ * backend reads it. That is stated at the top of football.controller.ts, and it is still
+ * true for stats. Live scores are the exception, and deliberately so — a scoreboard
+ * changes every few seconds, so routing it through BigQuery would add latency and cost
+ * to data that is stale by the time it lands. This proxies upstream instead, the way
+ * mlb-api.service.ts proxies MLB StatsAPI.
+ *
+ * Cost shape, which drives the caching below: the plan's Tier 2 subscription is 30,000
+ * calls a month. One /scoreboard call returns every game in a week, so board polling is
+ * cheap. But /live/plays, /metrics/wp and the box-score endpoints are PER GAME — a
+ * single open game page polling every 20s for three hours is ~540 calls. So per-game
+ * feeds are fetched on demand and cached server-side, which is what makes N concurrent
+ * viewers of one game cost one upstream call rather than N.
+ *
+ * College only. CFBD reports products ["cfb","cbb"], so there is no NFL here; NFL live
+ * data has to come from ESPN.
+ *
+ * Local development note: on a machine behind TLS inspection, Node's fetch fails here
+ * with SELF_SIGNED_CERT_IN_CHAIN while curl to the same host succeeds — curl trusts the
+ * corporate root through the OS keychain and Node does not. Export the root bundle and
+ * point NODE_EXTRA_CA_CERTS at it. App Engine is not behind such a proxy, so this only
+ * ever bites locally.
+ */
+
+import { cacheService } from './cache.service';
+import { getCacheKey } from '../utils/cache-keys';
+import { logger } from '../utils/logger';
+
+const BASE = 'https://api.collegefootballdata.com';
+
+/** Matches the football response cache. See football-cache.ts for the reasoning. */
+const MAX_CACHED_BYTES = 256 * 1024;
+
+/** Thrown when no key is configured, so handlers can answer 200 + note, not 500. */
+export class CfbdKeyMissing extends Error {
+  constructor() {
+    super('CFBD_API_KEY is not configured');
+    this.name = 'CfbdKeyMissing';
+  }
+}
+
+/** Thrown on a 401/403, which for CFBD means the tier does not include the endpoint. */
+export class CfbdNotEntitled extends Error {
+  constructor(path: string) {
+    super(`CFBD tier does not include ${path}`);
+    this.name = 'CfbdNotEntitled';
+  }
+}
+
+/**
+ * Live TTLs in seconds. Short enough to feel live, long enough that a burst of viewers
+ * is one upstream call. The scoreboard is the polling hot path; per-game feeds move more
+ * slowly than the clock does, so they tolerate a little more.
+ */
+export const CfbdTTL = {
+  scoreboard: 20,
+  livePlays: 20,
+  winProbability: 60,   // a completed game's curve never changes; see completedTTL
+  boxScore: 60,
+  drives: 60,
+  schedule: 3600,       // kickoff times move rarely
+} as const;
+
+/**
+ * A finished game is immutable, so its curve, box score and drives can be held for a
+ * day instead of a minute. Without this, browsing last week's games would re-fetch
+ * everything on every page view for no reason.
+ */
+export function completedTTL(base: number, isCompleted: boolean): number {
+  return isCompleted ? 86400 : base;
+}
+
+let cachedKey: string | null | undefined;
+
+/**
+ * Resolve the key once per instance. Lazy on purpose: importing this module must not
+ * require a key, so that the NFL paths and every batch endpoint keep working without one.
+ */
+function apiKey(): string {
+  if (cachedKey === undefined) {
+    cachedKey = process.env.CFBD_API_KEY || null;
+    if (!cachedKey) {
+      logger.warn('CFBD_API_KEY not set — live college endpoints will report unavailable');
+    }
+  }
+  if (!cachedKey) throw new CfbdKeyMissing();
+  return cachedKey;
+}
+
+export function hasApiKey(): boolean {
+  try { apiKey(); return true; } catch { return false; }
+}
+
+/** Test seam. */
+export function __resetKeyCache(): void {
+  cachedKey = undefined;
+}
+
+function buildUrl(path: string, params: Record<string, any>): string {
+  const qs = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) {
+    if (v !== undefined && v !== null && v !== '') qs.set(k, String(v));
+  }
+  const query = qs.toString();
+  return `${BASE}${path}${query ? `?${query}` : ''}`;
+}
+
+/**
+ * GET a CFBD endpoint, cached.
+ *
+ * The key is never logged and never included in the cache key. A non-2xx is surfaced as
+ * an error rather than cached, so a transient upstream failure does not stick around for
+ * the length of the TTL.
+ */
+export async function cfbdGet<T = any>(
+  path: string,
+  params: Record<string, any> = {},
+  ttl = 60,
+): Promise<T> {
+  const key = apiKey();
+  const cacheKey = getCacheKey(`cfbd:${path}`, params);
+
+  try {
+    const hit = await cacheService.get<T>(cacheKey);
+    if (hit) return hit;
+  } catch (error: any) {
+    logger.debug('cfbd cache read failed', { path, error: error?.message });
+  }
+
+  const url = buildUrl(path, params);
+  const started = Date.now();
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${key}`, Accept: 'application/json' },
+    signal: AbortSignal.timeout(20000),
+  });
+
+  if (res.status === 401 || res.status === 403) {
+    // The key is valid but the Patreon tier does not cover this endpoint. Distinct from
+    // a missing key, because the caller's answer is different: upgrade, not configure.
+    logger.warn('cfbd endpoint not entitled', { path, status: res.status });
+    throw new CfbdNotEntitled(path);
+  }
+  if (!res.ok) {
+    throw new Error(`CFBD ${path} responded ${res.status}`);
+  }
+
+  const body = (await res.json()) as T;
+  logger.debug('cfbd fetch', { path, ms: Date.now() - started });
+
+  try {
+    // Some responses are far too big to hold: /drives for a single week is ~924KB, and
+    // the in-process store has no size bound. Callers that need a slice of a large
+    // response should filter it and cache the slice themselves — see gameDrives.
+    const size = Buffer.byteLength(JSON.stringify(body));
+    if (size > MAX_CACHED_BYTES) {
+      logger.debug('cfbd response too large to cache', { path, size });
+    } else {
+      await cacheService.set(cacheKey, body, ttl);
+    }
+  } catch (error: any) {
+    logger.debug('cfbd cache write failed', { path, error: error?.message });
+  }
+  return body;
+}
+
+/** True where the error means "we cannot serve this", not "something broke". */
+export function isCfbdUnavailable(error: any): boolean {
+  return error instanceof CfbdKeyMissing || error instanceof CfbdNotEntitled;
+}

--- a/src/services/cfbd.service.ts
+++ b/src/services/cfbd.service.ts
@@ -75,6 +75,15 @@ export function completedTTL(base: number, isCompleted: boolean): number {
 
 let cachedKey: string | null | undefined;
 let keyLoad: Promise<string | null> | null = null;
+let keyRetryAfter = 0;
+
+/**
+ * How long to wait before re-reading a MISSING key. Same reasoning as the client id: a
+ * key that is found never changes, but caching its absence forever means a transient
+ * Secret Manager failure at cold start silently disables the live college endpoints on
+ * that instance until it is replaced.
+ */
+const MISSING_RETRY_MS = 60_000;
 
 const SECRET_NAME = process.env.CFBD_SECRET_NAME || 'cfbd-api-key';
 const SECRET_PROJECT = process.env.GCP_PROJECT_ID || 'hankstank';
@@ -118,9 +127,28 @@ async function loadKey(): Promise<string | null> {
 }
 
 async function apiKey(): Promise<string> {
-  if (cachedKey === undefined) {
-    keyLoad = keyLoad || loadKey();
-    cachedKey = await keyLoad;
+  if (!cachedKey) {
+    if (cachedKey === null && Date.now() < keyRetryAfter) throw new CfbdKeyMissing();
+
+    if (!keyLoad) {
+      keyLoad = loadKey().then((value) => {
+        cachedKey = value;
+        keyRetryAfter = value ? 0 : Date.now() + MISSING_RETRY_MS;
+        keyLoad = null;
+        return value;
+      }).catch((error) => {
+        cachedKey = null;
+        keyRetryAfter = Date.now() + MISSING_RETRY_MS;
+        keyLoad = null;
+        throw error;
+      });
+    }
+
+    try {
+      await keyLoad;
+    } catch {
+      throw new CfbdKeyMissing();
+    }
   }
   if (!cachedKey) throw new CfbdKeyMissing();
   return cachedKey;

--- a/src/services/cfbd.service.ts
+++ b/src/services/cfbd.service.ts
@@ -74,29 +74,67 @@ export function completedTTL(base: number, isCompleted: boolean): number {
 }
 
 let cachedKey: string | null | undefined;
+let keyLoad: Promise<string | null> | null = null;
+
+const SECRET_NAME = process.env.CFBD_SECRET_NAME || 'cfbd-api-key';
+const SECRET_PROJECT = process.env.GCP_PROJECT_ID || 'hankstank';
 
 /**
- * Resolve the key once per instance. Lazy on purpose: importing this module must not
- * require a key, so that the NFL paths and every batch endpoint keep working without one.
+ * Resolve the key from Secret Manager, once per instance.
+ *
+ * Read at runtime rather than injected at deploy time, and that is the point: App
+ * Engine already runs as the service account that holds secretAccessor on this secret,
+ * so nothing about deploying needs to know the key. Injecting it would have made every
+ * deploy — including CI's — depend on whoever ran it having the value to hand, which is
+ * the opposite of autonomous.
+ *
+ * The promise is memoised so a burst of first requests on a cold instance makes one
+ * Secret Manager call rather than one each.
  */
-function apiKey(): string {
-  if (cachedKey === undefined) {
-    cachedKey = process.env.CFBD_API_KEY || null;
-    if (!cachedKey) {
-      logger.warn('CFBD_API_KEY not set — live college endpoints will report unavailable');
+async function loadKey(): Promise<string | null> {
+  // An explicit env var still wins, which is what local development uses.
+  if (process.env.CFBD_API_KEY) return process.env.CFBD_API_KEY.trim();
+
+  try {
+    const { SecretManagerServiceClient } =
+      await import('@google-cloud/secret-manager');
+    const client = new SecretManagerServiceClient();
+    const [version] = await client.accessSecretVersion({
+      name: `projects/${SECRET_PROJECT}/secrets/${SECRET_NAME}/versions/latest`,
+    });
+    const value = version.payload?.data?.toString().trim() || null;
+    if (value) {
+      logger.info('CFBD key loaded from Secret Manager', { secret: SECRET_NAME });
     }
+    return value;
+  } catch (error: any) {
+    // Not fatal. Every college live endpoint answers "unavailable" with a note, and
+    // nothing that reads BigQuery is affected.
+    logger.warn('could not load the CFBD key from Secret Manager', {
+      secret: SECRET_NAME, error: error?.message,
+    });
+    return null;
+  }
+}
+
+async function apiKey(): Promise<string> {
+  if (cachedKey === undefined) {
+    keyLoad = keyLoad || loadKey();
+    cachedKey = await keyLoad;
   }
   if (!cachedKey) throw new CfbdKeyMissing();
   return cachedKey;
 }
 
-export function hasApiKey(): boolean {
-  try { apiKey(); return true; } catch { return false; }
+/** Whether a key is available. Resolves it if that has not happened yet. */
+export async function hasApiKey(): Promise<boolean> {
+  try { await apiKey(); return true; } catch { return false; }
 }
 
 /** Test seam. */
 export function __resetKeyCache(): void {
   cachedKey = undefined;
+  keyLoad = null;
 }
 
 function buildUrl(path: string, params: Record<string, any>): string {
@@ -120,7 +158,7 @@ export async function cfbdGet<T = any>(
   params: Record<string, any> = {},
   ttl = 60,
 ): Promise<T> {
-  const key = apiKey();
+  const key = await apiKey();
   const cacheKey = getCacheKey(`cfbd:${path}`, params);
 
   try {

--- a/src/utils/football-cache.ts
+++ b/src/utils/football-cache.ts
@@ -1,0 +1,136 @@
+/**
+ * Response caching for the football endpoints.
+ *
+ * Every football route queries BigQuery on every request today; nothing between the
+ * handler and the warehouse. This adds the missing layer at the call site rather than as
+ * middleware — src/middleware/cache.middleware.ts is a no-op placeholder, and a
+ * middleware version would have to buffer res.json and guess a key from the URL, which
+ * is both more magic and less accurate than the handler naming its own key.
+ *
+ * What this layer is and is not:
+ *
+ * The in-process store is a per-instance Map (Redis is disabled), and App Engine runs
+ * with min_instances 0 and up to 10 instances. So the hit rate is at best 1 - 1/N across
+ * warm instances and exactly zero on a cold start. It is a cost and latency
+ * optimisation; nothing may depend on it for correctness or for rate limiting.
+ *
+ * The Cache-Control header is doing at least as much work as the Map. It is shared across
+ * every instance by construction, which the Map is not, and for reference data like the
+ * teams list it is the difference that matters.
+ */
+
+import { Response } from 'express';
+import { cacheService } from '../services/cache.service';
+import { getCacheKey } from './cache-keys';
+import { logger } from './logger';
+
+/**
+ * Largest body worth holding in the in-process Map.
+ *
+ * cache.service's cleanup only evicts expired entries — there is no size bound and no
+ * LRU — and this runs on a 512MB F2 instance. The diagnostics payload alone is
+ * LIMIT 6000 rows wide, so caching it would be the fastest way to exhaust an instance.
+ */
+const MAX_CACHED_BYTES = 256 * 1024;
+
+/** Per-endpoint TTLs in seconds, chosen from how often the pipeline rewrites each table. */
+export const FootballCacheTTL = {
+  predictions: 900,      // in-week picks move as lines and rosters do
+  accuracy: 3600,
+  teamWeek: 3600,        // rewritten weekly by the ingest
+  teamSeason: 3600,
+  teams: 86400,          // reference data; changes about once a year
+  leaders: 3600,
+  players: 1800,
+  games: 3600,
+} as const;
+
+export const FootballCacheKeys = {
+  predictions: (sport: string, p: Record<string, any>) =>
+    getCacheKey(`ftbl:${sport}:preds`, p),
+  accuracy: (sport: string, p: Record<string, any>) =>
+    getCacheKey(`ftbl:${sport}:acc`, p),
+  teamWeek: (sport: string, p: Record<string, any>) =>
+    getCacheKey(`ftbl:${sport}:twk`, p),
+  teamSeason: (sport: string, p: Record<string, any>) =>
+    getCacheKey(`ftbl:${sport}:tsn`, p),
+  teams: (sport: string, p: Record<string, any>) =>
+    getCacheKey(`ftbl:${sport}:teams`, p),
+  leaders: (sport: string, p: Record<string, any>) =>
+    getCacheKey(`ftbl:${sport}:lead`, p),
+  players: (sport: string, p: Record<string, any>) =>
+    getCacheKey(`ftbl:${sport}:plyr`, p),
+  games: (sport: string, p: Record<string, any>) =>
+    getCacheKey(`ftbl:${sport}:games`, p),
+};
+
+/**
+ * A completed season is frozen, so it can be cached for a day whatever the base TTL says.
+ *
+ * This is where the hit rate actually comes from. The diagnostics and stats pages default
+ * to multi-season views, and 2024 is never going to change again. Mirrors the
+ * isHistorical branch already in getContextualTTL.
+ */
+export function seasonAwareTTL(
+  base: number,
+  season: number | undefined,
+  currentSeason: number,
+): number {
+  if (season !== undefined && Number.isFinite(season) && season < currentSeason) {
+    return Math.max(base, 86400);
+  }
+  return base;
+}
+
+export function currentSeason(): number {
+  const fromEnv = parseInt(process.env.CURRENT_SEASON || '', 10);
+  return Number.isFinite(fromEnv) ? fromEnv : new Date().getFullYear();
+}
+
+/**
+ * Serve `key` from cache, or run `produce` and store what it returns.
+ *
+ * `produce` returns the body to send; it must not write to the response itself. A thrown
+ * error propagates untouched so the handler's own three-tier error branches still decide
+ * what the caller sees — a missing table must not become a cached empty result.
+ */
+export async function serveCached<T>(
+  res: Response,
+  key: string,
+  ttl: number,
+  produce: () => Promise<T>,
+): Promise<void> {
+  let cached: T | null = null;
+  try {
+    cached = await cacheService.get<T>(key);
+  } catch (error: any) {
+    // A cache read failing is not a request failing.
+    logger.debug('football cache read failed', { key, error: error?.message });
+  }
+
+  if (cached) {
+    res.set('X-Cache', 'HIT');
+    res.set('Cache-Control', `public, max-age=${ttl}`);
+    res.json(cached);
+    return;
+  }
+
+  const body = await produce();
+
+  res.set('X-Cache', 'MISS');
+  res.set('Cache-Control', `public, max-age=${ttl}`);
+  res.json(body);
+
+  // Stored after responding: the caller should never wait on the write, and a body too
+  // large to hold is served normally rather than refused.
+  try {
+    const size = Buffer.byteLength(JSON.stringify(body));
+    if (size > MAX_CACHED_BYTES) {
+      logger.debug('football response too large to cache', { key, size });
+      return;
+    }
+    await cacheService.set(key, body, ttl);
+  } catch (error: any) {
+    logger.debug('football cache write failed', { key, error: error?.message });
+  }
+}

--- a/src/utils/football-cache.ts
+++ b/src/utils/football-cache.ts
@@ -134,3 +134,49 @@ export async function serveCached<T>(
     logger.debug('football cache write failed', { key, error: error?.message });
   }
 }
+
+/**
+ * Like serveCached, but the producer chooses the TTL.
+ *
+ * Needed where how long a response stays fresh depends on what is in it. A finished game
+ * is immutable and can be held for a day; one in progress is stale in seconds — and
+ * which it is only becomes known after fetching. Deciding the TTL up front would mean
+ * either re-assembling finished games every 20 seconds or serving a live game minutes
+ * late.
+ */
+export async function serveCachedDynamic<T>(
+  res: Response,
+  key: string,
+  produce: () => Promise<{ body: T; ttl: number }>,
+): Promise<void> {
+  let cached: { body: T; ttl: number } | null = null;
+  try {
+    cached = await cacheService.get<{ body: T; ttl: number }>(key);
+  } catch (error: any) {
+    logger.debug('football cache read failed', { key, error: error?.message });
+  }
+
+  if (cached?.body) {
+    res.set('X-Cache', 'HIT');
+    res.set('Cache-Control', `public, max-age=${cached.ttl}`);
+    res.json(cached.body);
+    return;
+  }
+
+  const { body, ttl } = await produce();
+
+  res.set('X-Cache', 'MISS');
+  res.set('Cache-Control', `public, max-age=${ttl}`);
+  res.json(body);
+
+  try {
+    const size = Buffer.byteLength(JSON.stringify(body));
+    if (size > MAX_CACHED_BYTES) {
+      logger.debug('football response too large to cache', { key, size });
+      return;
+    }
+    await cacheService.set(key, { body, ttl }, ttl);
+  } catch (error: any) {
+    logger.debug('football cache write failed', { key, error: error?.message });
+  }
+}

--- a/src/utils/football-request.ts
+++ b/src/utils/football-request.ts
@@ -1,0 +1,132 @@
+/**
+ * Shared request/response helpers for the football controllers.
+ *
+ * Extracted so every football handler answers the same way. The three-tier convention
+ * these encode is the important part:
+ *
+ *   404  the sport does not exist                     -> resolveSport
+ *   200  the sport cannot answer this, or the table
+ *        is not built yet, with meta.note explaining  -> respondUnavailable / isMissingTable
+ *   500  anything else, logged, generic message out
+ *
+ * The middle tier is the one worth protecting. A sport whose feed does not cover a
+ * resource is an expected state, not a failure, and 500ing it would make a normal gap
+ * look like an outage.
+ */
+
+import { Request, Response } from 'express';
+import { normalizeBigQueryTemporalValue } from './bq-normalize';
+import {
+  getFootballSport,
+  FootballSportConfig,
+} from '../config/football.config';
+
+/** Resolve :sport or answer 404. Returns null once the response has been sent. */
+export function resolveSport(
+  req: Request,
+  res: Response,
+  fallback = 'nfl',
+): FootballSportConfig | null {
+  const key = (req.params.sport || fallback).toLowerCase();
+  const sport = getFootballSport(key);
+  if (!sport) {
+    res.status(404).json({
+      success: false,
+      error: { code: 'UNKNOWN_SPORT', message: `Unknown football sport: ${key}` },
+    });
+    return null;
+  }
+  return sport;
+}
+
+/**
+ * BigQuery hands back DATE/TIMESTAMP as { value: "..." }; the frontend expects strings.
+ * Any new temporal column has to be added here or it reaches the client as an object.
+ */
+export function normalizeRow(row: any): any {
+  return {
+    ...row,
+    game_date: normalizeBigQueryTemporalValue(row.game_date),
+    predicted_at: normalizeBigQueryTemporalValue(row.predicted_at),
+  };
+}
+
+/**
+ * Is this error BigQuery telling us the table or a column is not there?
+ *
+ * Deliberately wider than "not found": querying a column a table lacks raises
+ * `Unrecognized name: week at [4:13]`, which the original narrower test missed, so a
+ * schema mismatch surfaced as a 500 rather than as an empty state. Both mean the same
+ * thing to a caller — this data is not available — so both answer 200 with a note.
+ */
+export function isMissingTable(error: any): boolean {
+  return /not found|does not exist|unrecognized name|no matching signature/i
+    .test(error?.message || '');
+}
+
+/**
+ * 200 with an explanation, for a resource this sport genuinely cannot serve.
+ *
+ * Takes the reason from config rather than hardcoding prose in a handler. A sentence
+ * written into a handler asserting "this sport has no X feed" becomes a lie the moment
+ * the config gains X, and nothing fails when it does — which is exactly how the college
+ * team-stats endpoint spent months telling people a table that existed did not.
+ */
+export function respondUnavailable(
+  res: Response,
+  sport: FootballSportConfig,
+  resource: string,
+  reason?: string,
+): void {
+  res.json({
+    success: true,
+    data: [],
+    meta: {
+      sport: sport.key,
+      label: sport.label,
+      total: 0,
+      count: 0,
+      sortable_fields: [],
+      note: reason
+        || `${sport.label} has no ${resource} feed wired up yet.`,
+    },
+  });
+}
+
+/** Paging, with the caps applied. BigQuery will happily return 500 wide rows. */
+export function parsePaging(
+  query: Record<string, any>,
+  defaults: { limit: number; max: number },
+): { limit: number; offset: number } {
+  const raw = parseInt(query.limit as string, 10);
+  const limit = Math.min(
+    Number.isFinite(raw) && raw > 0 ? raw : defaults.limit,
+    defaults.max,
+  );
+  const rawOffset = parseInt(query.offset as string, 10);
+  return {
+    limit,
+    offset: Number.isFinite(rawOffset) && rawOffset > 0 ? rawOffset : 0,
+  };
+}
+
+/**
+ * Pick a sort column from an allow-list.
+ *
+ * BigQuery cannot parameterize an ORDER BY identifier, so the value has to be
+ * interpolated — which makes the allow-list the only thing standing between a query
+ * string and the SQL. Returns null for an off-list value so the caller can 400 rather
+ * than quietly sorting by something else.
+ */
+export function pickSort(
+  requested: string | undefined,
+  allowed: string[],
+  fallback: string,
+): string | null {
+  if (!requested) return fallback;
+  return allowed.includes(requested) ? requested : null;
+}
+
+export function sortDirection(requested: string | undefined): 'ASC' | 'DESC' {
+  return (requested || '').toLowerCase() === 'asc' ? 'ASC' : 'DESC';
+}


### PR DESCRIPTION
## What this does

**The pick'em contest API** — pick sheet, submissions, public leaderboard — and the
football stats endpoints the site was missing.

Picks live in BigQuery beside the games, and everything follows from that: grading one
means joining it to the game's result and its closing spread, both already there, so
scoring is a **view** rather than a scheduled job. A result landing grades dependent
picks immediately; a corrected score corrects the leaderboard.

Also lights up two things that were already paid for and unreachable:
`cfb_season.team_season_stats` (154 columns, declared in config and read by no
controller) and `nfl_historical.teams` (every logo and colour, no endpoint).

## Notes for review

- **Two rules are server-side because a client cannot be trusted with either.** The
  kickoff lock is per game, not per week, computed in SQL against the server clock. And a
  pick records a **side** (`home`/`away`), never a team name — the two sports spell teams
  differently and the same feed disagrees with itself, so a stored name is a pick a rename
  can orphan.
- **One shared column vocabulary.** Each sport's table is aliased in SQL onto canonical
  names, so one client table renders the NFL's per-play EPA and college's PPA without
  knowing either. Without it, CFB would answer `player_name`/`team` and the NFL
  `player_display_name`/`recent_team`.
- **`Unrecognized name:` used to be a 500.** The missing-table guard only matched
  `/not found|does not exist/`, so querying a column a table lacks read as an outage
  rather than an empty state. Widened, and `getAccuracy` gained the branch it never had.
- **Secrets retry when missing.** A resolved secret is cached for the instance's life; a
  missing one is not. Caching absence meant storing the Google client ID had no effect on
  running instances, and a transient Secret Manager failure at cold start would have
  disabled sign-in permanently on that instance.
- The Vegas baseline for college was hardcoded `CAST(NULL)`. It is now real: for 2025 FBS
  the model is 72.9% against a 76.8% closing favourite.

## Testing

`npm test` — 153 tests across 14 suites, 55 new. Includes the first football and pick'em
route tests in this repo and the first `@google-cloud/bigquery` mock. Every endpoint was
verified against production BigQuery, and auth was verified to reject a token forged for
a different audience.
