### PR TITLE
Cache football and pick'em responses at the route layer

### DIFF
--- a/src/__tests__/pickem.routes.test.ts
+++ b/src/__tests__/pickem.routes.test.ts
@@ -60,6 +60,7 @@ import {
   mockQuery, rows, count, sentQueries, sentParamsFor, routeQueries,
 } from './helpers/bq-mock';
 import pickemRoutes from '../routes/pickem.routes';
+import { cacheService } from '../services/cache.service';
 import { __resetAdoptionMemo } from '../controllers/pickem.controller';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const authMock = require('../middleware/auth.middleware');
@@ -79,11 +80,14 @@ beforeAll((done) => {
   });
 });
 afterAll((done) => { server.close(done); });
-beforeEach(() => {
+beforeEach(async () => {
   jest.clearAllMocks();
   authMock.__setConfigured(true);
   // The adoption memo is per-instance, so it would otherwise carry between tests.
   __resetAdoptionMemo();
+  // So would the response cache. These tests assert on what the handler queried, and a
+  // cached body from the previous test means it queries nothing at all.
+  await cacheService.flush();
 });
 
 async function call(path: string, init: any = {}) {
@@ -91,6 +95,18 @@ async function call(path: string, init: any = {}) {
   return { status: res.status, body: await res.json() as any };
 }
 const signedIn = { headers: { Authorization: 'Bearer good' } };
+
+/**
+ * A call that is guaranteed to reach the handler.
+ *
+ * `/me` is cached per viewer, so a repeat request from the same signed-in user is
+ * normally served without touching BigQuery — which is the point of the cache, and
+ * exactly wrong for the tests that count how many queries a sequence of requests makes.
+ */
+async function callUncached(path: string, init: any = {}) {
+  await cacheService.flush();
+  return call(path, init);
+}
 
 const game = (over: any = {}) => ({
   game_id: 'g1', sport: 'nfl', division: null, season: 2026, week: 1,
@@ -430,10 +446,13 @@ describe('registering the signed-in user', () => {
   });
 
   it('does not re-register on every request', async () => {
+    // Each call flushes the response cache first, so the handler really runs all three
+    // times. Otherwise a cache hit would satisfy this test even with the memo removed,
+    // and the assertion would stop meaning anything.
     routeQueries([[/COUNT\(\*\) AS n/s, rows([{ n: 0 }])]]);
-    await call('/api/pickem/me?season=2026', signedIn);
-    await call('/api/pickem/me?season=2026', signedIn);
-    await call('/api/pickem/me?season=2026', signedIn);
+    await callUncached('/api/pickem/me?season=2026', signedIn);
+    await callUncached('/api/pickem/me?season=2026', signedIn);
+    await callUncached('/api/pickem/me?season=2026', signedIn);
     expect(sentQueries().filter((q) => /MERGE .*users/s.test(q))).toHaveLength(1);
   });
 
@@ -448,8 +467,8 @@ describe('registering the signed-in user', () => {
         return rows([]);
       }],
     ]);
-    await call('/api/pickem/me?season=2026', signedIn);
-    await call('/api/pickem/me?season=2026', signedIn);
+    await callUncached('/api/pickem/me?season=2026', signedIn);
+    await callUncached('/api/pickem/me?season=2026', signedIn);
 
     expect(sentQueries().filter((q) => /MERGE .*users/s.test(q)).length)
       .toBeGreaterThanOrEqual(2);

--- a/src/__tests__/responseCache.middleware.test.ts
+++ b/src/__tests__/responseCache.middleware.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for the response cache middleware.
+ *
+ * Three properties matter, and one of them is a security property: a per-viewer
+ * response must never be served to a different viewer. The pick sheet carries the
+ * caller's own selections, so a URL-only key would hand them to the next person.
+ */
+
+import express from 'express';
+import { Server } from 'http';
+
+jest.mock('../utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+import { cacheService } from '../services/cache.service';
+import { cacheGet } from '../middleware/responseCache.middleware';
+
+let server: Server;
+let baseUrl: string;
+let produce: jest.Mock;
+
+beforeAll((done) => {
+  const app = express();
+
+  // Stands in for whatever attached req.user upstream.
+  app.use((req: any, _res, next) => {
+    const who = req.headers['x-test-user'];
+    if (who) req.user = { userId: String(who) };
+    next();
+  });
+
+  app.get('/plain', cacheGet({ ttl: 60 }), (_req, res) => {
+    res.json({ success: true, value: produce() });
+  });
+  app.get('/mine', cacheGet({ ttl: 60 }), (req: any, res) => {
+    res.json({ success: true, viewer: req.user?.userId ?? 'anon', value: produce() });
+  });
+  app.get('/boom', cacheGet({ ttl: 60 }), (_req, res) => {
+    produce();
+    res.status(500).json({ success: false, error: { code: 'X', message: 'no' } });
+  });
+  app.get('/soft-fail', cacheGet({ ttl: 60 }), (_req, res) => {
+    produce();
+    res.json({ success: false, error: { code: 'Y', message: 'no' } });
+  });
+  app.get('/huge', cacheGet({ ttl: 60 }), (_req, res) => {
+    produce();
+    res.json({ success: true, blob: 'x'.repeat(400 * 1024) });
+  });
+  app.put('/plain', cacheGet({ ttl: 60 }), (_req, res) => {
+    res.json({ success: true, value: produce() });
+  });
+
+  server = app.listen(0, () => {
+    const addr = server.address();
+    if (!addr || typeof addr === 'string') throw new Error('no port bound');
+    baseUrl = `http://127.0.0.1:${addr.port}`;
+    done();
+  });
+});
+afterAll((done) => { server.close(done); });
+
+beforeEach(async () => {
+  let n = 0;
+  produce = jest.fn(() => { n += 1; return n; });
+  await cacheService.flush();
+});
+
+const get = async (path: string, user?: string) => {
+  const res = await fetch(`${baseUrl}${path}`, {
+    headers: user ? { 'x-test-user': user } : {},
+  });
+  return { status: res.status, cache: res.headers.get('x-cache'), body: await res.json() as any };
+};
+
+describe('cacheGet', () => {
+  it('runs the handler once and serves the repeat from cache', async () => {
+    const a = await get('/plain');
+    const b = await get('/plain');
+    expect(a.cache).toBe('MISS');
+    expect(b.cache).toBe('HIT');
+    expect(produce).toHaveBeenCalledTimes(1);
+    expect(b.body.value).toBe(a.body.value);
+  });
+
+  it('never serves one viewer a response produced for another', async () => {
+    // The security property. The pick sheet carries the caller's own picks.
+    const mine = await get('/mine', 'user-a');
+    expect(mine.body.viewer).toBe('user-a');
+
+    const theirs = await get('/mine', 'user-b');
+    expect(theirs.cache).toBe('MISS');
+    expect(theirs.body.viewer).toBe('user-b');
+
+    const anon = await get('/mine');
+    expect(anon.body.viewer).toBe('anon');
+
+    // Three distinct viewers, three separate productions.
+    expect(produce).toHaveBeenCalledTimes(3);
+  });
+
+  it('serves the same viewer from their own entry', async () => {
+    await get('/mine', 'user-a');
+    const again = await get('/mine', 'user-a');
+    expect(again.cache).toBe('HIT');
+    expect(again.body.viewer).toBe('user-a');
+    expect(produce).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not cache a failed response', async () => {
+    // A transient failure served for a whole TTL would turn a blip into an outage.
+    await get('/boom');
+    const second = await get('/boom');
+    expect(second.status).toBe(500);
+    expect(second.cache).toBe('MISS');
+    expect(produce).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cache a 200 that reports success: false', async () => {
+    await get('/soft-fail');
+    const second = await get('/soft-fail');
+    expect(second.cache).toBe('MISS');
+    expect(produce).toHaveBeenCalledTimes(2);
+  });
+
+  it('serves an oversized body without storing it', async () => {
+    await get('/huge');
+    const second = await get('/huge');
+    expect(second.status).toBe(200);
+    expect(second.cache).toBe('MISS');
+    expect(produce).toHaveBeenCalledTimes(2);
+  });
+
+  it('sets a shared Cache-Control, which outlives the per-instance store', async () => {
+    const res = await fetch(`${baseUrl}/plain`);
+    expect(res.headers.get('cache-control')).toBe('public, max-age=60');
+  });
+
+  it('leaves non-GET requests alone', async () => {
+    // A PUT that returned a cached body would be a bug with teeth.
+    await fetch(`${baseUrl}/plain`, { method: 'PUT' });
+    const second = await fetch(`${baseUrl}/plain`, { method: 'PUT' });
+    expect(second.headers.get('x-cache')).toBeNull();
+    expect(produce).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/__tests__/responseCache.middleware.test.ts
+++ b/src/__tests__/responseCache.middleware.test.ts
@@ -33,7 +33,7 @@ beforeAll((done) => {
   app.get('/plain', cacheGet({ ttl: 60 }), (_req, res) => {
     res.json({ success: true, value: produce() });
   });
-  app.get('/mine', cacheGet({ ttl: 60 }), (req: any, res) => {
+  app.get('/mine', cacheGet({ ttl: 60, perViewer: true }), (req: any, res) => {
     res.json({ success: true, viewer: req.user?.userId ?? 'anon', value: produce() });
   });
   app.get('/boom', cacheGet({ ttl: 60 }), (_req, res) => {
@@ -132,9 +132,38 @@ describe('cacheGet', () => {
     expect(produce).toHaveBeenCalledTimes(2);
   });
 
-  it('sets a shared Cache-Control, which outlives the per-instance store', async () => {
+  it('sets a shared Cache-Control on a public route, which outlives the per-instance store', async () => {
     const res = await fetch(`${baseUrl}/plain`);
     expect(res.headers.get('cache-control')).toBe('public, max-age=60');
+  });
+
+  describe('what shared caches are allowed to do', () => {
+    // App Engine serves through Google's frontend, so these headers are the difference
+    // between a fast page and one visitor's picks appearing on another's screen.
+
+    it('forbids shared caching of a per-viewer route, even anonymously', async () => {
+      // Anonymous matters most: the URL is identical either way, so a publicly cached
+      // anonymous body is what would then be served to everyone who signs in.
+      const anon = await fetch(`${baseUrl}/mine`);
+      expect(anon.headers.get('cache-control')).toBe('private, max-age=60');
+
+      const signedIn = await fetch(`${baseUrl}/mine`, { headers: { 'x-test-user': 'user-a' } });
+      expect(signedIn.headers.get('cache-control')).toBe('private, max-age=60');
+    });
+
+    it('varies a per-viewer route on Authorization', async () => {
+      // `private` stops a shared cache storing it; this stops any cache answering a
+      // signed-in request from an entry built for a different credential.
+      const res = await fetch(`${baseUrl}/mine`);
+      expect(res.headers.get('vary')).toMatch(/Authorization/i);
+    });
+
+    it('downgrades a public route to private once a viewer is attached', async () => {
+      // Belt and braces: a route nobody remembered to declare per-viewer still must not
+      // have a signed-in response stored in a shared cache.
+      const res = await fetch(`${baseUrl}/plain`, { headers: { 'x-test-user': 'user-a' } });
+      expect(res.headers.get('cache-control')).toBe('private, max-age=60');
+    });
   });
 
   it('leaves non-GET requests alone', async () => {

--- a/src/controllers/pickem.controller.ts
+++ b/src/controllers/pickem.controller.ts
@@ -22,6 +22,7 @@
 import { Request, Response } from 'express';
 import { BigQuery } from '@google-cloud/bigquery';
 import { logger } from '../utils/logger';
+import { cacheService } from '../services/cache.service';
 import { normalizeBigQueryTemporalValue } from '../utils/bq-normalize';
 import { isMissingTable } from '../utils/football-request';
 import { googleClientId } from '../middleware/auth.middleware';
@@ -313,6 +314,11 @@ export async function submitPicks(req: Request, res: Response): Promise<void> {
     if (accepted.length) {
       await ensureUser(user);
       await upsertPicks(accepted);
+      // The sheet and the leaderboard are cached, and a save changes both. Without this
+      // the user would watch their own pick revert for the length of the TTL — the most
+      // alarming way a cache can be wrong, because it looks like the save failed.
+      // Cheap and league-wide: someone else's pick moves the leaderboard too.
+      await cacheService.delPattern('hank:pk:*');
     }
 
     res.json({

--- a/src/middleware/responseCache.middleware.ts
+++ b/src/middleware/responseCache.middleware.ts
@@ -1,0 +1,95 @@
+/**
+ * Response caching as route middleware.
+ *
+ * The earlier approach wrapped each handler's body in a `serveCached` call, which worked
+ * — and then seven football handlers and every pick'em handler shipped without it,
+ * because adding caching was a separate act of remembering per endpoint. Football was
+ * paying full BigQuery latency on every request while MLB, which caches in its service
+ * layer, felt instant. This makes caching a property of the route instead, so a new
+ * endpoint cannot quietly arrive uncached.
+ *
+ * Two things make it safe rather than magic:
+ *
+ *   The key is the URL AND the viewer, not a guess. Some of these responses are
+ *   per-person — the pick sheet carries the caller's own selections — and a URL-only key
+ *   would hand one viewer's picks to the next.
+ *
+ *   Only a successful response is stored. A 500, a 404, or a body carrying
+ *   `success: false` is passed through untouched, so a transient failure cannot be
+ *   served for the length of a TTL.
+ *
+ * `serveCachedDynamic` still exists for the one case this cannot express: a response
+ * whose freshness depends on its own content, like a game that is cacheable for a day
+ * once it has finished and for seconds while it is being played.
+ */
+
+import { Request, Response, NextFunction } from 'express';
+import { cacheService } from '../services/cache.service';
+import { getCacheKey } from '../utils/cache-keys';
+import { logger } from '../utils/logger';
+
+/** Bodies past this are served but not stored; see football-cache for the reasoning. */
+const MAX_CACHED_BYTES = 256 * 1024;
+
+export interface CacheOptions {
+  /** Seconds. Also sent as Cache-Control max-age, which is shared across instances. */
+  ttl: number;
+  /**
+   * Prefix for readable keys. Defaults to the route path, which is usually enough.
+   */
+  prefix?: string;
+}
+
+export function cacheGet({ ttl, prefix }: CacheOptions) {
+  return async function cacheGetMiddleware(
+    req: Request, res: Response, next: NextFunction,
+  ): Promise<void> {
+    // Only idempotent reads. A PUT that returned a cached body would be a bug with
+    // teeth, so this never applies to anything else.
+    if (req.method !== 'GET' || ttl <= 0) return next();
+
+    const key = getCacheKey(prefix || 'route', {
+      url: req.originalUrl,
+      // Anonymous callers share one bucket; they are identical by definition.
+      viewer: req.user?.userId || 'anon',
+    });
+
+    try {
+      const hit = await cacheService.get<any>(key);
+      if (hit) {
+        res.set('X-Cache', 'HIT');
+        res.set('Cache-Control', `public, max-age=${ttl}`);
+        res.json(hit);
+        return;
+      }
+    } catch (error: any) {
+      logger.debug('response cache read failed', { key, error: error?.message });
+    }
+
+    // Intercept the handler's own res.json so it needs no knowledge of caching.
+    const send = res.json.bind(res);
+    res.json = (body: any) => {
+      res.set('X-Cache', 'MISS');
+      res.set('Cache-Control', `public, max-age=${ttl}`);
+      const out = send(body);
+
+      const worthCaching = res.statusCode === 200 && body?.success !== false;
+      if (worthCaching) {
+        // After responding, so the caller never waits on the write.
+        try {
+          const size = Buffer.byteLength(JSON.stringify(body));
+          if (size > MAX_CACHED_BYTES) {
+            logger.debug('response too large to cache', { key, size });
+          } else {
+            void cacheService.set(key, body, ttl);
+          }
+        } catch (error: any) {
+          logger.debug('response cache write failed', { key, error: error?.message });
+        }
+      }
+      return out;
+    };
+
+    next();
+  };
+}

--- a/src/middleware/responseCache.middleware.ts
+++ b/src/middleware/responseCache.middleware.ts
@@ -38,15 +38,37 @@ export interface CacheOptions {
    * Prefix for readable keys. Defaults to the route path, which is usually enough.
    */
   prefix?: string;
+  /**
+   * Set on any route whose body can differ by who is asking.
+   *
+   * This controls what shared caches are allowed to do, which matters here because App
+   * Engine serves through Google's frontend. Such a response is sent `private` so no
+   * shared cache stores it at all, plus `Vary: Authorization` so a signed-in request is
+   * never answered from an entry populated anonymously — that second one is the failure
+   * `private` alone does not cover, since a cache keys on the URL and would otherwise
+   * hand a signed-in visitor the anonymous pick sheet with none of their picks on it.
+   *
+   * The in-process key always carries the viewer regardless of this flag; this is only
+   * about caches between here and the browser.
+   */
+  perViewer?: boolean;
 }
 
-export function cacheGet({ ttl, prefix }: CacheOptions) {
+export function cacheGet({ ttl, prefix, perViewer }: CacheOptions) {
   return async function cacheGetMiddleware(
     req: Request, res: Response, next: NextFunction,
   ): Promise<void> {
     // Only idempotent reads. A PUT that returned a cached body would be a bug with
     // teeth, so this never applies to anything else.
     if (req.method !== 'GET' || ttl <= 0) return next();
+
+    // A route declared per-viewer stays private even for an anonymous caller: the URL
+    // is the same either way, so letting the anonymous response be publicly cached is
+    // what would poison it for everyone who signs in.
+    const scoped = perViewer || Boolean(req.user);
+    const cacheControl = `${scoped ? 'private' : 'public'}, max-age=${ttl}`;
+    // res.vary appends; res.set would replace, and CORS has already put Origin there.
+    if (perViewer) res.vary('Authorization');
 
     const key = getCacheKey(prefix || 'route', {
       url: req.originalUrl,
@@ -58,7 +80,7 @@ export function cacheGet({ ttl, prefix }: CacheOptions) {
       const hit = await cacheService.get<any>(key);
       if (hit) {
         res.set('X-Cache', 'HIT');
-        res.set('Cache-Control', `public, max-age=${ttl}`);
+        res.set('Cache-Control', cacheControl);
         res.json(hit);
         return;
       }
@@ -70,7 +92,7 @@ export function cacheGet({ ttl, prefix }: CacheOptions) {
     const send = res.json.bind(res);
     res.json = (body: any) => {
       res.set('X-Cache', 'MISS');
-      res.set('Cache-Control', `public, max-age=${ttl}`);
+      res.set('Cache-Control', cacheControl);
       const out = send(body);
 
       const worthCaching = res.statusCode === 200 && body?.success !== false;

--- a/src/routes/football.routes.ts
+++ b/src/routes/football.routes.ts
@@ -28,19 +28,37 @@ import {
   getGameDetail,
 } from '../controllers/football-games.controller';
 
+import { cacheGet } from '../middleware/responseCache.middleware';
+
+/**
+ * TTLs chosen from how often the pipeline rewrites each table, not from traffic.
+ * Predictions move in-week as lines and rosters do; a season's stat tables are
+ * rewritten weekly; team metadata changes about once a year.
+ */
+const TTL = {
+  predictions: 900,
+  accuracy: 3600,
+  diagnostics: 900,
+  teamStats: 3600,
+  leaders: 3600,
+  players: 1800,
+  games: 3600,
+  teams: 86400,
+} as const;
+
 const router = Router({ mergeParams: true });
 
 // accuracy must be declared before the bare /predictions route so it is not shadowed
-router.get('/:sport/predictions/accuracy', getAccuracy);
-router.get('/:sport/predictions/diagnostics', getDiagnostics);
-router.get('/:sport/predictions', getPredictions);
-router.get('/:sport/rankings', getRankings);
+router.get('/:sport/predictions/accuracy', cacheGet({ ttl: TTL.accuracy, prefix: 'ftbl:acc' }), getAccuracy);
+router.get('/:sport/predictions/diagnostics', cacheGet({ ttl: TTL.diagnostics, prefix: 'ftbl:diag' }), getDiagnostics);
+router.get('/:sport/predictions', cacheGet({ ttl: TTL.predictions, prefix: 'ftbl:preds' }), getPredictions);
+router.get('/:sport/rankings', cacheGet({ ttl: TTL.teamStats, prefix: 'ftbl:rank' }), getRankings);
 // season totals before the bare /stats/teams so the more specific path wins
 router.get('/:sport/stats/teams/season', searchTeamSeasonStats);
-router.get('/:sport/stats/teams', searchTeamStats);
-router.get('/:sport/stats/leaders', getLeaders);
-router.get('/:sport/stats/players', searchPlayers);
-router.get('/:sport/stats/games', searchGames);
+router.get('/:sport/stats/teams', cacheGet({ ttl: TTL.teamStats, prefix: 'ftbl:twk' }), searchTeamStats);
+router.get('/:sport/stats/leaders', cacheGet({ ttl: TTL.leaders, prefix: 'ftbl:lead' }), getLeaders);
+router.get('/:sport/stats/players', cacheGet({ ttl: TTL.players, prefix: 'ftbl:plyr' }), searchPlayers);
+router.get('/:sport/stats/games', cacheGet({ ttl: TTL.games, prefix: 'ftbl:games' }), searchGames);
 router.get('/:sport/teams', getTeams);
 // Live scoreboard and schedule. Declared before /games/:gameId so neither is captured
 // as a game id, and kept distinct from /stats/games, which serves completed results

--- a/src/routes/pickem.routes.ts
+++ b/src/routes/pickem.routes.ts
@@ -19,12 +19,26 @@ import {
   getConfig,
 } from '../controllers/pickem.controller';
 
+import { cacheGet } from '../middleware/responseCache.middleware';
+
+/**
+ * The sheet's TTL is deliberately short. Its `locked` flag comes from the server clock,
+ * so a longer one would show a game as open for that long after kickoff. Submitting
+ * re-checks the lock against the table, so the worst case is a briefly stale button and
+ * never an accepted late pick.
+ */
+const TTL = { games: 30, leaderboard: 120, me: 60 } as const;
+
 const router = Router();
 
+// Deliberately uncached. It touches no BigQuery, so caching buys nothing, and its
+// answer depends on a Secret Manager lookup whose negative result is already held for a
+// minute — stacking a response cache on top is how sign-in stayed switched off for
+// minutes after the client id was actually added.
 router.get('/config', getConfig);
-router.get('/games', attachUser, getWeekGames);
-router.get('/leaderboard', attachUser, getLeaderboard);
-router.get('/me', requireUser, getMyPicks);
+router.get('/games', attachUser, cacheGet({ ttl: TTL.games, prefix: 'pk:games' }), getWeekGames);
+router.get('/leaderboard', attachUser, cacheGet({ ttl: TTL.leaderboard, prefix: 'pk:board' }), getLeaderboard);
+router.get('/me', requireUser, cacheGet({ ttl: TTL.me, prefix: 'pk:me' }), getMyPicks);
 router.put('/picks', requireUser, submitPicks);
 
 export default router;

--- a/src/routes/pickem.routes.ts
+++ b/src/routes/pickem.routes.ts
@@ -36,9 +36,9 @@ const router = Router();
 // minute — stacking a response cache on top is how sign-in stayed switched off for
 // minutes after the client id was actually added.
 router.get('/config', getConfig);
-router.get('/games', attachUser, cacheGet({ ttl: TTL.games, prefix: 'pk:games' }), getWeekGames);
-router.get('/leaderboard', attachUser, cacheGet({ ttl: TTL.leaderboard, prefix: 'pk:board' }), getLeaderboard);
-router.get('/me', requireUser, cacheGet({ ttl: TTL.me, prefix: 'pk:me' }), getMyPicks);
+router.get('/games', attachUser, cacheGet({ ttl: TTL.games, prefix: 'pk:games', perViewer: true }), getWeekGames);
+router.get('/leaderboard', attachUser, cacheGet({ ttl: TTL.leaderboard, prefix: 'pk:board', perViewer: true }), getLeaderboard);
+router.get('/me', requireUser, cacheGet({ ttl: TTL.me, prefix: 'pk:me', perViewer: true }), getMyPicks);
 router.put('/picks', requireUser, submitPicks);
 
 export default router;

--- a/src/routes/rankings.routes.ts
+++ b/src/routes/rankings.routes.ts
@@ -6,10 +6,11 @@
  */
 
 import { Router } from 'express';
+import { cacheGet } from '../middleware/responseCache.middleware';
 import { getRankings } from '../controllers/rankings.controller';
 
 const router = Router({ mergeParams: true });
 
-router.get('/:sport', getRankings);
+router.get('/:sport', cacheGet({ ttl: 3600, prefix: 'rank' }), getRankings);
 
 export default router;


### PR DESCRIPTION
## Why

Football felt slow next to baseball because it was. MLB caches inside its service layer;
football's controllers cached nothing, so **13 of 17 football and pick'em endpoints hit
BigQuery on every request.** Measured against production before this change — note the
second request costs the same as the first, and no `x-cache` header exists anywhere:

| Endpoint | 1st | 2nd |
|---|---|---|
| `cfb/predictions` | 0.96s | 0.71s |
| `cfb/predictions/accuracy` | 2.51s | 1.17s |
| `cfb/stats/players` | 1.18s | 1.09s |
| `pickem/games` | 1.19s | 1.46s |

API quota was never the problem — `cfbdGet` already caches upstream fetches, and CFBD
usage is 99 of 30,000 calls this month. The cost was BigQuery round-trips.

## What

Caching per handler is what caused this: `serveCached` exists and works, but four handlers
adopted it and thirteen shipped without, because remembering was a separate act per
endpoint. `cacheGet({ttl, prefix})` makes caching a property of the route, so a new
endpoint cannot quietly arrive uncached.

Verified locally against real BigQuery: **1.1–2.7s → 2ms** on repeats, every route
reporting HIT/MISS.

Two properties make it safe rather than magic. The key is the URL *and* the viewer,
because some bodies are per-person — the pick sheet carries the caller's own picks, and a
URL-only key would hand them to the next visitor. And only a successful response is
stored, so a transient BigQuery failure isn't served for a whole TTL.

Saving a pick clears the pick'em keys. Without that you'd watch your own selection revert
for 30 seconds, which looks exactly like a failed save.

`/pickem/config` is deliberately left uncached: it touches no BigQuery, and its answer
depends on a Secret Manager lookup whose negative result is already held for a minute.
Stacking a response cache on that is how sign-in stayed switched off for minutes after the
client id was added.

## The bug the first pass had

The first commit sent `Cache-Control: public` on every cached route, including the pick
sheet and `/me`. App Engine serves through Google's frontend, so that invited a shared
cache to hand one visitor's picks to the next — the leak the in-process key prevents,
reintroduced one layer further out.

Per-viewer routes now send `private` plus `Vary: Authorization`. Both are needed: `private`
stops a shared cache storing it, and Vary stops any cache answering a signed-in request
from an entry populated anonymously (which would show the anonymous sheet with none of your
picks — a correctness bug rather than a leak, but a confusing one). Uses `res.vary()`, not
`res.set('Vary')`, which would have replaced the CORS `Vary: Origin`; verified live as
`Origin, Authorization`.

## Tests

169 pass. New `responseCache.middleware.test.ts` covers HIT/MISS, viewer isolation, the
refusal to cache 500s and `success: false` bodies, the 256KB size refusal, non-GET
passthrough, and the three shared-cache header properties.

Two pick'em tests had to stop reusing a URL: they count how many queries a sequence of
requests makes, and a cache hit would have satisfied them even with the memo they test
removed entirely.

🤖 Generated with Claude Code at The Home Depot