### PR TITLE
Remove a flaky test that asserted setTimeout works

### DIFF
--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -211,19 +211,18 @@ describe('BigQuery Sync Integration Tests', () => {
     });
   });
 
-  describe('Rate limiting', () => {
-    
-    it('should add delay between API calls', async () => {
-      const delayMs = 1000;
-      const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
-      
-      const startTime = Date.now();
-      await delay(delayMs);
-      const endTime = Date.now();
-      
-      expect(endTime - startTime).toBeGreaterThanOrEqual(delayMs);
-    });
-  });
+  // A "rate limiting" test lived here and was removed. It declared its own `delay`
+  // helper and asserted that `Date.now()` advanced by at least 1000ms across a 1000ms
+  // `setTimeout` — so it referenced no application code and could not detect any
+  // regression in it, while costing a real second of CI and flaking at the boundary
+  // (it failed on 999ms, because setTimeout's deadline and Date.now() are not the same
+  // clock and Date.now() has millisecond granularity).
+  //
+  // The behaviour it was named after is real: bigquery-sync.service.ts calls
+  // `this.delay(1000)` between MLB API calls. Genuinely covering that means importing
+  // the service, which constructs GCP clients at module load — the reason every test in
+  // this file asserts arithmetic instead. So that delay is deliberately left uncovered
+  // rather than pretended-covered.
 
   describe('Data transformation', () => {
     


### PR DESCRIPTION
## Why now

This test failed CI on the merge of #7 and blocked its deploy, with:

```
expect(received).toBeGreaterThanOrEqual(expected)
Expected: >= 1000
Received:    999
```

It had passed on #7's PR run against identical code, so it was a flake rather than a
regression — but it can only ever be a flake.

## Why it can't be fixed, only removed

The test declared its own `delay` helper and asserted that `Date.now()` advanced by at
least 1000ms across a 1000ms `setTimeout`. It referenced **no application code**, so it
could not detect a regression in anything this repo ships. `setTimeout`'s deadline and
`Date.now()` are not the same clock and `Date.now()` is millisecond-granular, so an
exact-boundary comparison can legitimately come up a millisecond short — at a cost of a
real second of CI per run.

## The gap, recorded rather than hidden

The behaviour it was named after is real: `bigquery-sync.service.ts:933` calls
`this.delay(1000)` between MLB API calls. Covering that genuinely means importing
`bigQuerySyncService`, a singleton that constructs GCP clients at module load — which is
precisely why every other test in this file asserts arithmetic instead of importing the
service. A comment in place of the test says so, so the next person sees an
acknowledged gap rather than a tautology standing in for coverage.

168 tests pass.

🤖 Generated with Claude Code at The Home Depot